### PR TITLE
Skeleton of FastAPI-based Container Service

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,8 +26,6 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install -r requirements.txt
         python -m pip install -r requirements_test.txt
-        python -m pip uninstall -y funcx
-        python -m pip install "git+https://github.com/funcx-faas/funcX.git@dev#egg=funcx&subdirectory=funcx_sdk"
         pip list
     - name: Check for vulnerabilities in libraries
       run: |
@@ -48,11 +46,3 @@ jobs:
       shell: bash
       run: echo "##[set-output name=imagetag;]$(echo ${GITHUB_REF##*/})"
       id: extract_tag_name
-
-    - name: Build funcX-container-service Image
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: funcx/container-service:${{ steps.extract_tag_name.outputs.imagetag }}
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-        tag: "${GITHUB_REF##*/}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,22 +4,16 @@ RUN apk update && \
     apk add postgresql-dev libffi-dev g++ make libressl-dev git
 
 # Create a group and user
-RUN addgroup -S uwsgi && adduser -S uwsgi -G uwsgi
+RUN addgroup -S http && adduser -S http -G http
 
-WORKDIR /opt/funcx-container-service
+WORKDIR /opt/
 
-COPY ./requirements.txt .
-RUN pip install -r requirements.txt
-RUN  pip uninstall -y funcx && \
-     pip install "git+https://github.com/funcx-faas/funcX.git@dev#egg=funcx&subdirectory=funcx_sdk"
+COPY ./requirements.txt /tmp/
+RUN pip install -r /tmp/requirements.txt
 
-RUN pip install --disable-pip-version-check uwsgi
+COPY ./funcx_container_service/ ./
 
-COPY uwsgi.ini .
-COPY ./funcx_container_service/ ./funcx_container_service/
-COPY web-entrypoint.sh .
-
-USER uwsgi
+USER http
 EXPOSE 5000
 
-CMD sh web-entrypoint.sh
+CMD uvicorn funcx_container_service:app --host '0.0.0.0' --port 5000

--- a/README.md
+++ b/README.md
@@ -1,50 +1,31 @@
 # FuncX Container Service
 
-The Container service runs in a container on Flask behind uWSGI. It's
+The Container service runs in a container using FastAPI. It's
 responsible for creating and managing container environments for running
 functions on funcX.
-
-## Routes
-
-This service will have the following routes:
-
-### /environment
-
-This route accepts a POST with a payload containing environment details to
-create new containers, and a GET to retrieve environment state and details.
-
-#### POST
-
-Request payload:
-
-```
-{
-  'name': '<ENVIRONMENT-NAME>',
-  'docker-image': '<DOCKER-IMAGE>',
-}
-```
-
-Response payload:
-
-```
-{
-  'uuid': '<ENVIRONMENT-UUID>'
-}
-```
-
-The environment identifier will be used to run functions in the created
-environment.
-
-#### GET
-
-Gets the state of the environment. To return build logs, etc., pass the query
-parameter `?log=true`.
-
-## Docker Container
 
 You can run the service inside a docker container.
 
 ```
->> docker build -t container_service:latest .
->> docker run -d -p 5000:5000 container_service:latest
+$ docker build -t container_service:latest .
+$ docker run -d -p 5000:5000 container_service:latest
 ```
+
+Or set up a build environment with
+
+```
+$ pip install -r requirements.txt
+```
+
+Then start the server with
+
+```
+$ uvicorn funcx_container_service:app --reload
+```
+
+The full API is documented at `http://server:port/docs`.
+
+A database needs to be (TBD).
+The Docker daemon needs to be running (with the control socket)
+bind mounted into the container if applicable. Also requires Singularity 3.x
+in the build environment.

--- a/conf/app.conf.template
+++ b/conf/app.conf.template
@@ -1,1 +1,0 @@
-TESTING = false

--- a/funcx_container_service/__init__.py
+++ b/funcx_container_service/__init__.py
@@ -1,18 +1,136 @@
-from flask import Flask
-from flask_restful import Api
+from uuid import UUID
+from typing import Optional
 
-from funcx_container_service.resources.environments import Environments
+from fastapi import (FastAPI, UploadFile, File, Response,
+                     BackgroundTasks, Depends)
+from pydantic import AnyUrl
+from sqlalchemy.orm import Session
+
+from . import database, build, landlord
+from .models import ContainerSpec, StatusResponse
+from .dockerfile import emit_dockerfile
+
+app = FastAPI()
 
 
-def create_app(app_config_object=None):
-    application = Flask(__name__)
-    api = Api(application)
+def db_session():
+    session = database.Session()
+    try:
+        yield session
+        session.commit()
+    except:  # noqa: E722
+        session.rollback()
+        raise
+    finally:
+        session.close()
 
-    if app_config_object is not None:
-        application.config.from_object(app_config_object)
-    else:
-        application.config.from_envvar("APP_CONFIG_FILE")
 
-    api.add_resource(Environments, "/environments")
+@app.post("/build", response_model=UUID)
+async def simple_build(spec: ContainerSpec, tasks: BackgroundTasks,
+                       db: Session = Depends(db_session)):
+    """Build a container based on a JSON specification.
 
-    return application
+    Returns an ID that can be used to query container status.
+    """
+    container_id = await database.store_spec(db, spec)
+
+    alt = await landlord.find_existing(db, spec)
+    if not alt:
+        tasks.add_task(build.background_build, container_id, None)
+
+    return await database.add_build(db, container_id)
+
+
+@app.post("/build_advanced", response_model=UUID)
+async def advanced_build(tasks: BackgroundTasks, repo: UploadFile = File(...),
+                         db: Session = Depends(db_session),
+                         s3=Depends(build.s3_connection)):
+    """Build a container using repo2docker.
+
+    The repo must be a directory in `.tar.gz` format.
+    Returns an ID that can be used to query container status.
+    """
+    container_id = await database.store_tarball(db, s3, repo.file)
+
+    tasks.add_task(build.background_build, container_id, repo.file)
+    return await database.add_build(db, container_id)
+
+
+@app.get("/{build_id}/dockerfile")
+async def dockerfile(build_id: UUID, db: Session = Depends(db_session)):
+    """Generate a Dockerfile to build the given container.
+
+    Does not support "advanced build" (tarball) containers.
+    Produces a container that is roughly compatible with repo2docker.
+    """
+    pkgs = await database.get_spec(db, str(build_id))
+    return Response(content=emit_dockerfile(pkgs['apt'], pkgs['conda'],
+                                            pkgs['pip']),
+                    media_type="text/plain")
+
+
+@app.get("/{build_id}/status", response_model=StatusResponse)
+async def status(build_id: UUID, db: Session = Depends(db_session)):
+    """Check the status of a previously submitted build."""
+    return await database.status(db, str(build_id))
+
+
+@app.get("/{build_id}/docker", response_model=Optional[str])
+async def get_docker(build_id: UUID, tasks: BackgroundTasks,
+                     db: Session = Depends(db_session),
+                     ecr=Depends(build.ecr_connection)):
+    """Get the Docker build for a container.
+
+    If the container is not ready, null is returned, and a build is
+    initiated (if not already in progress). If the build specification
+    was invalid and cannot be completed, returns HTTP 410: Gone.
+    """
+
+    container_id, url = await build.make_ecr_url(db, ecr, str(build_id))
+    if not url:
+        tasks.add_task(build.background_build, container_id, None)
+    return url
+
+
+@app.get("/{build_id}/docker_log", response_model=Optional[AnyUrl])
+async def get_docker_log(build_id: UUID, tasks: BackgroundTasks,
+                         db: Session = Depends(db_session),
+                         s3=Depends(build.s3_connection)):
+    """Get the Docker build log for a container.
+
+    If the build is still in progress, null is returned.
+    """
+
+    url = await build.make_s3_url(db, s3, 'docker-logs', str(build_id))
+    return url
+
+
+@app.get("/{build_id}/singularity", response_model=Optional[AnyUrl])
+async def get_singularity(build_id: UUID, tasks: BackgroundTasks,
+                          db: Session = Depends(db_session),
+                          s3=Depends(build.s3_connection)):
+    """Get the Docker build for a container.
+
+    If the container is not ready, null is returned, and a build is
+    initiated (if not already in progress). If the build specification
+    was invalid and cannot be completed, returns HTTP 410: Gone.
+    """
+
+    container_id, url = await build.make_s3_container_url(
+            db, s3, 'singularity', str(build_id))
+    if not url:
+        tasks.add_task(build.background_build, container_id, None)
+    return url
+
+
+@app.get("/{build_id}/singularity_log", response_model=Optional[AnyUrl])
+async def get_singularity_log(build_id: UUID, tasks: BackgroundTasks,
+                              db: Session = Depends(db_session),
+                              s3=Depends(build.s3_connection)):
+    """Get the Singularity build log for a container.
+
+    If the build is still in progress, null is returned.
+    """
+
+    url = await build.make_s3_url(db, s3, 'singularity-logs', str(build_id))
+    return url

--- a/funcx_container_service/application.py
+++ b/funcx_container_service/application.py
@@ -1,6 +1,0 @@
-from funcx_container_service import create_app
-
-app = create_app()
-
-if __name__ == "__main__":
-    app.run("0.0.0.0", port=5000)

--- a/funcx_container_service/build.py
+++ b/funcx_container_service/build.py
@@ -1,0 +1,281 @@
+import os
+import json
+import asyncio
+import tarfile
+import tempfile
+import docker
+import boto3
+from pathlib import Path
+from datetime import datetime
+from docker.errors import ImageNotFound
+from fastapi import HTTPException
+from . import database, landlord
+from .models import ContainerSpec, ContainerState
+
+
+REPO2DOCKER_CMD = 'jupyter-repo2docker --no-run --image-name {} {}'
+SINGULARITY_CMD = 'singularity build --force {} docker-daemon://{}:latest'
+DOCKER_BASE_URL = 'unix://var/run/docker.sock'
+
+
+def s3_connection():
+    return boto3.client('s3')
+
+
+def ecr_connection():
+    return boto3.client('ecr')
+
+
+def s3_upload(s3, filename, bucket, key):
+    s3.upload_file(filename, bucket, key)
+
+
+def s3_check(db, s3, bucket, container_id):
+    try:
+        s3.head_object(Bucket=bucket, Key=container_id)
+    except s3.exceptions.NoSuchKey:
+        return False
+    return True
+
+
+def ecr_check(db, ecr, container_id):
+    try:
+        resp = ecr.list_images(repositoryName=container_id)
+        return len(resp['imageIds']) > 0
+    except ecr.exceptions.RepositoryNotFoundException:
+        return False
+    return True
+
+
+def docker_name(container_id):
+    # XXX need to add repo info here
+    return f'funcx_{container_id}'
+
+
+def docker_size(container_id):
+    docker_client = docker.APIClient(base_url=DOCKER_BASE_URL)
+    try:
+        inspect = docker_client.inspect_image(docker_name(container_id))
+        return inspect['VirtualSize']
+    except ImageNotFound:
+        return None
+
+
+def env_from_spec(spec):
+    out = {
+        "name": "funcx-container",
+        "channels": ["conda-forge"],
+        "dependencies": ["pip"]
+    }
+    if spec.conda:
+        out["dependencies"] += list(spec.conda)
+    if spec.pip:
+        out["dependencies"].append({"pip": list(spec.pip)})
+    return out
+
+
+async def build_spec(s3, container_id, spec, tmp_dir):
+    if spec.apt:
+        with (tmp_dir / 'apt.txt').open('w') as f:
+            f.writelines([x + '\n' for x in spec.apt])
+    with (tmp_dir / 'environment.yml').open('w') as f:
+        json.dump(env_from_spec(spec), f, indent=4)
+    return await repo2docker_build(s3, container_id, tmp_dir)
+
+
+async def build_tarball(s3, container_id, tarball, tmp_dir):
+    with tarfile.open(tarball) as tar_obj:
+        await asyncio.to_thread(tar_obj.extractall, path=tmp_dir)
+
+    # For some reason literally any file will pass through this tarfile check
+    if len(os.listdir(tmp_dir)) == 0:
+        raise HTTPException(status_code=415, detail="Invalid tarball")
+
+    return await repo2docker_build(s3, container_id, tmp_dir)
+
+
+async def repo2docker_build(s3, container_id, temp_dir):
+    with tempfile.NamedTemporaryFile() as out:
+        proc = await asyncio.create_subprocess_shell(
+                REPO2DOCKER_CMD.format(docker_name(container_id), temp_dir),
+                stdout=out, stderr=out)
+        await proc.communicate()
+
+        out.flush()
+        out.seek(0)
+        await asyncio.to_thread(
+                s3_upload, s3, out.name, 'docker-logs', container_id)
+
+    if proc.returncode != 0:
+        return None
+    return docker_size(container_id)
+
+
+async def singularity_build(s3, container_id):
+    with tempfile.NamedTemporaryFile() as sif, \
+            tempfile.NamedTemporaryFile() as out:
+        proc = await asyncio.create_subprocess_shell(
+                SINGULARITY_CMD.format(sif.name, docker_name(container_id)),
+                stdout=out, stderr=out)
+        await proc.communicate()
+
+        await asyncio.to_thread(
+                s3_upload, s3, out.name, 'singularity-logs', container_id)
+
+        if proc.returncode != 0:
+            return None
+        container_size = os.stat(sif.name).st_size
+        if container_size > 0:
+            await asyncio.to_thread(
+                    s3_upload, s3, sif.name, 'singularity', container_id)
+        else:
+            container_size = None
+        return container_size
+
+
+async def docker_build(s3, container, tarball):
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        if container.specification:
+            container_size = await build_spec(
+                    s3,
+                    container.id,
+                    ContainerSpec.parse_raw(container.specification),
+                    tmp)
+        else:
+            if not tarball:
+                download = tempfile.NamedTemporaryFile()
+                tarball = download.name
+                await asyncio.to_thread(
+                        s3.download_file, 'repos', container.id, tarball)
+            container_size = await build_tarball(
+                    s3,
+                    container.id,
+                    tarball,
+                    tmp)
+            # just to be safe
+            os.unlink(tarball)
+    return container_size
+
+
+async def make_s3_url(db, s3, bucket, build_id, is_container=True):
+    for row in db.query(database.Build).filter(database.Build.id == build_id):
+        container = row.container
+        break
+    else:
+        raise HTTPException(status_code=404)
+
+    if not s3_check(db, s3, bucket, container.id):
+        return None
+
+    url = s3.generate_presigned_url(
+            'get_object',
+            Params={'Bucket': bucket, 'Key': container.id})
+    return url
+
+
+async def make_s3_container_url(db, s3, bucket, build_id):
+    for row in db.query(database.Build).filter(database.Build.id == build_id):
+        container = row.container
+        break
+    else:
+        raise HTTPException(status_code=404)
+
+    if container.state == ContainerState.failed:
+        raise HTTPException(status_code=410)
+    elif container.state != ContainerState.ready:
+        alt = await landlord.find_existing(
+                db, ContainerSpec.parse_raw(container.specification))
+        if alt:
+            container = alt
+        else:
+            return container.id, None
+
+    if not s3_check(db, s3, bucket, container.id):
+        await remove(db, container.id)
+        return container.id, None
+
+    container.last_used = datetime.now()
+
+    url = s3.generate_presigned_url(
+            'get_object',
+            Params={'Bucket': bucket, 'Key': container.id})
+    return container.id, url
+
+
+async def make_ecr_url(db, ecr, build_id):
+    for row in db.query(database.Build).filter(database.Build.id == build_id):
+        container = row.container
+        break
+    else:
+        raise HTTPException(status_code=404)
+
+    if container.state == ContainerState.failed:
+        raise HTTPException(status_code=410)
+    elif container.state != ContainerState.ready:
+        alt = await landlord.find_existing(
+                db, ContainerSpec.parse_raw(container.specification))
+        if alt:
+            container = alt
+        else:
+            return container.id, None
+
+    if not ecr_check(db, ecr, container.id):
+        await remove(db, container.id)
+        return container.id, None
+
+    container.last_used = datetime.now()
+
+    return container.id, docker_name(container.id)
+
+
+async def background_build(container_id, tarball):
+    with database.session_scope() as db:
+        if not await database.start_build(db, container_id):
+            return
+        container = db.query(database.Container).filter(
+                database.Container.id == container_id).one()
+
+        s3 = s3_connection()
+        docker_client = docker.APIClient(base_url=DOCKER_BASE_URL)
+        try:
+            container.docker_size = await docker_build(s3, container, tarball)
+            if container.docker_size is None:
+                container.state = ContainerState.failed
+                return
+            container.singularity_size = await singularity_build(
+                    s3, container_id)
+            if container.singularity_size is None:
+                container.state = ContainerState.failed
+                return
+            await asyncio.to_thread(docker_client.push,
+                                    docker_name(container_id))
+            container.state = ContainerState.ready
+        finally:
+            container.builder = None
+            await landlord.cleanup(db)
+
+
+async def remove(db, container_id):
+    container = db.query(database.Container).filter(
+            database.Container.id == container_id).one()
+    container.state = ContainerState.pending
+    container.builder = None
+    container.docker_size = None
+    container.singularity_size = None
+
+    s3 = s3_connection()
+    ecr = ecr_connection()
+
+    await asyncio.to_thread(s3.delete_object,
+                            {'Bucket': 'singularity', 'Key': container_id})
+    await asyncio.to_thread(s3.delete_object,
+                            {'Bucket': 'singularity-logs',
+                             'Key': container_id})
+    await asyncio.to_thread(s3.delete_object,
+                            {'Bucket': 'docker-logs', 'Key': container_id})
+    try:
+        await asyncio.to_thread(ecr.delete_repository,
+                                repositoryName=container_id, force=True)
+    except ecr.exceptions.RepositoryNotFoundException:
+        pass

--- a/funcx_container_service/config.py
+++ b/funcx_container_service/config.py
@@ -1,11 +1,11 @@
-class Config(object):
+class DefaultConfig(object):
     DEBUG = False
     TESTING = False
 
 
-class TestConfig(object):
+class TestConfig(DefaultConfig):
     TESTING = True
 
 
-class DebugConfig(object):
+class DebugConfig(DefaultConfig):
     DEBUG = True

--- a/funcx_container_service/database.py
+++ b/funcx_container_service/database.py
@@ -1,0 +1,183 @@
+# not really a database, just dump everything in the fs for now
+
+import json
+import uuid
+import asyncio
+import hashlib
+from datetime import datetime
+from contextlib import contextmanager
+
+from fastapi import HTTPException
+from sqlalchemy import (create_engine, Column, String, Integer,
+                        ForeignKey, DateTime, Enum)
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker, relationship
+from sqlalchemy.pool import StaticPool
+
+from .models import ContainerState, StatusResponse
+from . import build
+
+
+RUN_ID = str(uuid.uuid4())
+
+Base = declarative_base()
+Session = sessionmaker()
+_engine = create_engine(
+        'sqlite://',
+        connect_args={'check_same_thread': False},
+        poolclass=StaticPool)
+Session.configure(bind=_engine)
+
+
+class Container(Base):
+    __tablename__ = 'containers'
+
+    id = Column(String, primary_key=True)
+    last_used = Column(DateTime)
+    state = Column(Enum(ContainerState))
+    specification = Column(String)
+    docker_size = Column(Integer)
+    singularity_size = Column(Integer)
+    builder = Column(String)
+
+    builds = relationship('Build', back_populates='container')
+
+
+class Build(Base):
+    __tablename__ = 'builds'
+
+    id = Column(String, primary_key=True)
+    container_hash = Column(String, ForeignKey('containers.id'))
+    # Add auth/user info
+
+    container = relationship('Container', back_populates='builds')
+
+
+@contextmanager
+def session_scope():
+    session = Session()
+    try:
+        yield session
+        session.commit()
+    except:  # noqa: E722
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def hash_file(pth):
+    digest = hashlib.sha256()
+    with open(pth, 'rb') as f:
+        while True:
+            data = f.read(65536)
+            if not data:
+                break
+            digest.update(data)
+    return digest.hexdigest()
+
+
+async def store_spec(db, spec):
+    container_id = spec.digest()
+
+    for row in db.query(Container).filter(Container.id == container_id):
+        return container_id
+
+    cont = Container()
+    cont.id = container_id
+    cont.last_used = datetime.now()
+    cont.specification = spec.json()
+    cont.state = ContainerState.pending
+    db.add(cont)
+
+    return container_id
+
+
+async def store_tarball(db, s3, tarball):
+    tarball.rollover()
+    container_id = await asyncio.to_thread(hash_file, tarball.name)
+
+    for row in db.query(Container).filter(Container.id == container_id):
+        return container_id
+
+    await asyncio.to_thread(
+            s3.upload_file, tarball.name, 'repos', container_id)
+
+    cont = Container()
+    db.add(cont)
+    cont.id = container_id
+    cont.last_used = datetime.now()
+    cont.state = ContainerState.pending
+
+    return container_id
+
+
+async def get_spec(db, build_id):
+    for row in db.query(Build).filter(Build.id == build_id):
+        build = row
+        break
+    else:
+        raise HTTPException(status_code=404)
+
+    spec = build.container.specification
+    if not spec:
+        raise HTTPException(status_code=400)
+
+    return json.loads(spec)
+
+
+async def add_build(db, container_id):
+    build = Build()
+    build.id = str(uuid.uuid4())
+    build.container_hash = container_id
+    db.add(build)
+    db.commit()  # needed to get relationships
+    build.container.last_used = datetime.now()
+    return build.id
+
+
+async def status(db, build_id):
+    for row in db.query(Build).filter(Build.id == build_id):
+        build = row
+        container = row.container
+        break
+    else:
+        raise HTTPException(status_code=404)
+
+    return StatusResponse(
+        id=build.id,
+        recipe_checksum=container.id,
+        last_used=container.last_used,
+        docker_size=container.docker_size,
+        singularity_size=container.singularity_size,
+        status=container.state
+        )
+
+
+async def start_build(db, container_id):
+    container = db.query(Container).filter(
+            Container.id == container_id).populate_existing(
+            ).with_for_update().one()
+    try:
+        if container.state == ContainerState.ready:
+            # nothing to do
+            return False
+        elif container.state == ContainerState.failed:
+            # already failed, not going to change
+            return False
+        elif (container.state == ContainerState.building
+                and container.builder == RUN_ID):
+            # build already started by this server
+            return False
+        elif container.state == ContainerState.building:
+            # build from a previous (crashed) server, clean up
+            await build.remove(db, container_id)
+
+        container.state = ContainerState.building
+        container.builder = RUN_ID
+        return True
+    finally:
+        db.commit()
+
+
+Base.metadata.create_all(_engine)

--- a/funcx_container_service/dockerfile.py
+++ b/funcx_container_service/dockerfile.py
@@ -1,0 +1,401 @@
+import shlex
+
+# flake8: noqa E501
+
+HEADER = r"""
+FROM buildpack-deps:bionic
+
+# avoid prompts from apt
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Set up locales properly
+RUN apt-get -qq update && \
+    apt-get -qq install --yes --no-install-recommends locales > /dev/null && \
+    apt-get -qq purge && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# Use bash as default shell, rather than sh
+ENV SHELL /bin/bash
+
+# Set up user
+ENV NB_USER funcx_container
+ENV HOME /home/${NB_USER}
+ENV NB_UID 1000
+
+RUN groupadd \
+        --gid ${NB_UID} \
+        ${NB_USER} && \
+    useradd \
+        --comment "Default user" \
+        --create-home \
+        --gid ${NB_UID} \
+        --no-log-init \
+        --shell /bin/bash \
+        --uid ${NB_UID} \
+        ${NB_USER}
+
+RUN wget --quiet -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key |  apt-key add - && \
+    DISTRO="bionic" && \
+    echo "deb https://deb.nodesource.com/node_10.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list && \
+    echo "deb-src https://deb.nodesource.com/node_10.x $DISTRO main" >> /etc/apt/sources.list.d/nodesource.list
+
+# Base package installs are not super interesting to users, so hide their outputs
+# If install fails for some reason, errors will still be printed
+RUN apt-get -qq update && \
+    apt-get -qq install --yes --no-install-recommends \
+       less \
+       nodejs \
+       unzip \
+       > /dev/null && \
+    apt-get -qq purge && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/*
+
+EXPOSE 8888
+
+# Environment variables required for build
+ENV APP_BASE /srv
+ENV NPM_DIR ${APP_BASE}/npm
+ENV NPM_CONFIG_GLOBALCONFIG ${NPM_DIR}/npmrc
+ENV CONDA_DIR ${APP_BASE}/conda
+ENV NB_PYTHON_PREFIX ${CONDA_DIR}/envs/notebook
+ENV KERNEL_PYTHON_PREFIX ${NB_PYTHON_PREFIX}
+# Special case PATH
+ENV PATH ${NB_PYTHON_PREFIX}/bin:${CONDA_DIR}/bin:${NPM_DIR}/bin:${PATH}
+# If scripts required during build are present, copy them
+
+RUN ( echo '# enable conda and activate the notebook environment' && \
+echo 'CONDA_PROFILE="${CONDA_DIR}/etc/profile.d/conda.sh"' && \
+echo 'test -f $CONDA_PROFILE && . $CONDA_PROFILE' && \
+echo 'if [[ "${KERNEL_PYTHON_PREFIX}" != "${NB_PYTHON_PREFIX}" ]]; then' && \
+echo '    # if the kernel is a separate env, stack them' && \
+echo '    # so both are on PATH, notebook first' && \
+echo '    conda activate ${KERNEL_PYTHON_PREFIX}' && \
+echo '    conda activate --stack ${NB_PYTHON_PREFIX}' && \
+echo '' && \
+echo '    # even though it'"'"'s second on $PATH' && \
+echo '    # make sure CONDA_DEFAULT_ENV is the *kernel* env' && \
+echo '    # so that `!conda install PKG` installs in the kernel env' && \
+echo '    # where user packages are installed, not the notebook env' && \
+echo '    # which only contains UI when the two are different' && \
+echo '    export CONDA_DEFAULT_ENV="${KERNEL_PYTHON_PREFIX}"' && \
+echo else && \
+echo '    conda activate ${NB_PYTHON_PREFIX}' && \
+echo fi ) > /etc/profile.d/activate-conda.sh
+
+RUN ( echo 'name: r2d' && \
+echo channels: && \
+echo '  - conda-forge' && \
+echo '  - defaults' && \
+echo '  - conda-forge/label/broken' && \
+echo dependencies: && \
+echo '  - _libgcc_mutex=0.1=conda_forge' && \
+echo '  - _openmp_mutex=4.5=0_gnu' && \
+echo '  - alembic=1.3.3=py_0' && \
+echo '  - async_generator=1.10=py_0' && \
+echo '  - attrs=19.3.0=py_0' && \
+echo '  - backcall=0.1.0=py_0' && \
+echo '  - bleach=3.1.0=py_0' && \
+echo '  - blinker=1.4=py_1' && \
+echo '  - ca-certificates=2019.11.28=hecc5488_0' && \
+echo '  - certifi=2019.11.28=py37_0' && \
+echo '  - certipy=0.1.3=py_0' && \
+echo '  - cffi=1.13.2=py37h8022711_0' && \
+echo '  - chardet=3.0.4=py37_1003' && \
+echo '  - cryptography=2.8=py37h72c5cf5_1' && \
+echo '  - decorator=4.4.1=py_0' && \
+echo '  - defusedxml=0.6.0=py_0' && \
+echo '  - entrypoints=0.3=py37_1000' && \
+echo '  - idna=2.8=py37_1000' && \
+echo '  - importlib_metadata=1.5.0=py37_0' && \
+echo '  - inflect=4.0.0=py37_1' && \
+echo '  - ipykernel=5.1.4=py37h5ca1d4c_0' && \
+echo '  - ipython=7.11.1=py37h5ca1d4c_0' && \
+echo '  - ipython_genutils=0.2.0=py_1' && \
+echo '  - ipywidgets=7.5.1=py_0' && \
+echo '  - jaraco.itertools=5.0.0=py_0' && \
+echo '  - jedi=0.16.0=py37_0' && \
+echo '  - jinja2=2.11.0=py_0' && \
+echo '  - json5=0.8.5=py_0' && \
+echo '  - jsonschema=3.2.0=py37_0' && \
+echo '  - jupyter_client=5.3.4=py37_1' && \
+echo '  - jupyter_core=4.6.1=py37_0' && \
+echo '  - jupyter_telemetry=0.0.4=py_0' && \
+echo '  - jupyterhub-base=1.1.0=py37_2' && \
+echo '  - jupyterhub-singleuser=1.1.0=py37_2' && \
+echo '  - jupyterlab=1.2.6=py_0' && \
+echo '  - jupyterlab_server=1.0.6=py_0' && \
+echo '  - krb5=1.16.4=h2fd8d38_0' && \
+echo '  - ld_impl_linux-64=2.33.1=h53a641e_8' && \
+echo '  - libcurl=7.65.3=hda55be3_0' && \
+echo '  - libedit=3.1.20170329=hf8c457e_1001' && \
+echo '  - libffi=3.2.1=he1b5a44_1006' && \
+echo '  - libgcc-ng=9.2.0=h24d8f2e_2' && \
+echo '  - libgomp=9.2.0=h24d8f2e_2' && \
+echo '  - libsodium=1.0.17=h516909a_0' && \
+echo '  - libssh2=1.8.2=h22169c7_2' && \
+echo '  - libstdcxx-ng=9.2.0=hdf63c60_2' && \
+echo '  - mako=1.1.0=py_0' && \
+echo '  - markupsafe=1.1.1=py37h516909a_0' && \
+echo '  - mistune=0.8.4=py37h516909a_1000' && \
+echo '  - more-itertools=8.2.0=py_0' && \
+echo '  - nbconvert=5.6.1=py37_0' && \
+echo '  - nbformat=5.0.4=py_0' && \
+echo '  - ncurses=6.1=hf484d3e_1002' && \
+echo '  - notebook=6.0.3=py37_0' && \
+echo '  - nteract_on_jupyter=2.1.3=py_0' && \
+echo '  - oauthlib=3.0.1=py_0' && \
+echo '  - openssl=1.1.1d=h516909a_0' && \
+echo '  - pamela=1.0.0=py_0' && \
+echo '  - pandoc=2.9.1.1=0' && \
+echo '  - pandocfilters=1.4.2=py_1' && \
+echo '  - parso=0.6.0=py_0' && \
+echo '  - pexpect=4.8.0=py37_0' && \
+echo '  - pickleshare=0.7.5=py37_1000' && \
+echo '  - pip=20.0.2=py37_0' && \
+echo '  - prometheus_client=0.7.1=py_0' && \
+echo '  - prompt_toolkit=3.0.3=py_0' && \
+echo '  - ptyprocess=0.6.0=py_1001' && \
+echo '  - pycparser=2.19=py37_1' && \
+echo '  - pycurl=7.43.0.5=py37h16ce93b_0' && \
+echo '  - pygments=2.5.2=py_0' && \
+echo '  - pyjwt=1.7.1=py_0' && \
+echo '  - pyopenssl=19.1.0=py37_0' && \
+echo '  - pyrsistent=0.15.7=py37h516909a_0' && \
+echo '  - pysocks=1.7.1=py37_0' && \
+echo '  - python=3.7.6=h357f687_2' && \
+echo '  - python-dateutil=2.8.1=py_0' && \
+echo '  - python-editor=1.0.4=py_0' && \
+echo '  - python-json-logger=0.1.11=py_0' && \
+echo '  - pyzmq=18.1.1=py37h1768529_0' && \
+echo '  - readline=8.0=hf8c457e_0' && \
+echo '  - requests=2.22.0=py37_1' && \
+echo '  - ruamel.yaml=0.16.6=py37h516909a_0' && \
+echo '  - ruamel.yaml.clib=0.2.0=py37h516909a_0' && \
+echo '  - send2trash=1.5.0=py_0' && \
+echo '  - setuptools=45.1.0=py37_0' && \
+echo '  - six=1.14.0=py37_0' && \
+echo '  - sqlalchemy=1.3.13=py37h516909a_0' && \
+echo '  - sqlite=3.30.1=hcee41ef_0' && \
+echo '  - terminado=0.8.3=py37_0' && \
+echo '  - testpath=0.4.4=py_0' && \
+echo '  - tk=8.6.10=hed695b0_0' && \
+echo '  - tornado=6.0.3=py37h516909a_0' && \
+echo '  - traitlets=4.3.3=py37_0' && \
+echo '  - urllib3=1.25.7=py37_0' && \
+echo '  - wcwidth=0.1.8=py_0' && \
+echo '  - webencodings=0.5.1=py_1' && \
+echo '  - wheel=0.34.1=py37_0' && \
+echo '  - widgetsnbextension=3.5.1=py37_0' && \
+echo '  - xz=5.2.4=h14c3975_1001' && \
+echo '  - zeromq=4.3.2=he1b5a44_2' && \
+echo '  - zipp=2.1.0=py_0' && \
+echo '  - zlib=1.2.11=h516909a_1006' && \
+echo 'prefix: /opt/conda/envs/r2d' ) > /tmp/environment.yml
+
+RUN ( echo '#!/bin/bash' && \
+echo '# This downloads and installs a pinned version of miniconda' && \
+echo 'set -ex' && \
+echo '' && \
+echo 'cd $(dirname $0)' && \
+echo MINICONDA_VERSION=4.7.12.1 && \
+echo CONDA_VERSION=4.7.12 && \
+echo '# Only MD5 checksums are available for miniconda' && \
+echo '# Can be obtained from https://repo.continuum.io/miniconda/' && \
+echo 'MD5SUM="81c773ff87af5cfac79ab862942ab6b3"' && \
+echo '' && \
+echo 'URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"' && \
+echo INSTALLER_PATH=/tmp/miniconda-installer.sh && \
+echo '' && \
+echo '# make sure we don'"'"'t do anything funky with user'"'"'s $HOME' && \
+echo '# since this is run as root' && \
+echo 'unset HOME' && \
+echo '' && \
+echo 'wget --quiet $URL -O ${INSTALLER_PATH}' && \
+echo 'chmod +x ${INSTALLER_PATH}' && \
+echo '' && \
+echo '# check md5 checksum' && \
+echo 'if ! echo "${MD5SUM}  ${INSTALLER_PATH}" | md5sum  --quiet -c -; then' && \
+echo '    echo "md5sum mismatch for ${INSTALLER_PATH}, exiting!"' && \
+echo '    exit 1' && \
+echo fi && \
+echo '' && \
+echo 'bash ${INSTALLER_PATH} -b -p ${CONDA_DIR}' && \
+echo 'export PATH="${CONDA_DIR}/bin:$PATH"' && \
+echo '' && \
+echo '# Allow easy direct installs from conda forge' && \
+echo 'conda config --system --add channels conda-forge' && \
+echo '' && \
+echo '# Do not attempt to auto update conda or dependencies' && \
+echo 'conda config --system --set auto_update_conda false' && \
+echo 'conda config --system --set show_channel_urls true' && \
+echo '' && \
+echo '# bug in conda 4.3.>15 prevents --set update_dependencies' && \
+echo 'echo '"'"'update_dependencies: false'"'"' >> ${CONDA_DIR}/.condarc' && \
+echo '' && \
+echo '# install conda itself' && \
+echo 'if [[ "${CONDA_VERSION}" != "${MINICONDA_VERSION}" ]]; then' && \
+echo '    conda install -yq conda==${CONDA_VERSION}' && \
+echo fi && \
+echo '' && \
+echo '# avoid future changes to default channel_priority behavior' && \
+echo 'conda config --system --set channel_priority "flexible"' && \
+echo '' && \
+echo 'echo "installing notebook env:"' && \
+echo 'cat /tmp/environment.yml' && \
+echo 'conda env create -p ${NB_PYTHON_PREFIX} -f /tmp/environment.yml' && \
+echo '' && \
+echo '# empty conda history file,' && \
+echo '# which seems to result in some effective pinning of packages in the initial env,' && \
+echo '# which we don'"'"'t intend.' && \
+echo '# this file must not be *removed*, however' && \
+echo 'echo '"'"''"'"' > ${NB_PYTHON_PREFIX}/conda-meta/history' && \
+echo '' && \
+echo 'if [[ -f /tmp/kernel-environment.yml ]]; then' && \
+echo '    # install kernel env and register kernelspec' && \
+echo '    echo "installing kernel env:"' && \
+echo '    cat /tmp/kernel-environment.yml' && \
+echo '' && \
+echo '    conda env create -p ${KERNEL_PYTHON_PREFIX} -f /tmp/kernel-environment.yml' && \
+echo '    ${KERNEL_PYTHON_PREFIX}/bin/ipython kernel install --prefix "${NB_PYTHON_PREFIX}"' && \
+echo '    echo '"'"''"'"' > ${KERNEL_PYTHON_PREFIX}/conda-meta/history' && \
+echo '    conda list -p ${KERNEL_PYTHON_PREFIX}' && \
+echo fi && \
+echo '' && \
+echo '# Clean things out!' && \
+echo 'conda clean --all -f -y' && \
+echo '' && \
+echo '# Remove the big installer so we don'"'"'t increase docker image size too much' && \
+echo 'rm ${INSTALLER_PATH}' && \
+echo '' && \
+echo '# Remove the pip cache created as part of installing miniconda' && \
+echo 'rm -rf /root/.cache' && \
+echo '' && \
+echo 'chown -R $NB_USER:$NB_USER ${CONDA_DIR}' && \
+echo '' && \
+echo 'conda list -n root' && \
+echo 'conda list -p ${NB_PYTHON_PREFIX}' ) > /tmp/install-miniconda.bash
+
+RUN mkdir -p ${NPM_DIR} && \
+chown -R ${NB_USER}:${NB_USER} ${NPM_DIR}
+
+USER ${NB_USER}
+RUN npm config --global set prefix ${NPM_DIR}
+
+USER root
+RUN bash /tmp/install-miniconda.bash && \
+rm /tmp/install-miniconda.bash /tmp/environment.yml
+
+
+# Allow target path repo is cloned to be configurable
+ARG REPO_DIR=${HOME}
+ENV REPO_DIR ${REPO_DIR}
+WORKDIR ${REPO_DIR}
+
+# We want to allow two things:
+#   1. If there's a .local/bin directory in the repo, things there
+#      should automatically be in path
+#   2. postBuild and users should be able to install things into ~/.local/bin
+#      and have them be automatically in path
+#
+# The XDG standard suggests ~/.local/bin as the path for local user-specific
+# installs. See https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+ENV PATH ${HOME}/.local/bin:${REPO_DIR}/.local/bin:${PATH}
+
+# The rest of the environment
+ENV CONDA_DEFAULT_ENV ${KERNEL_PYTHON_PREFIX}
+# Run pre-assemble scripts! These are instructions that depend on the content
+# of the repository but don't access any files in the repository. By executing
+# them before copying the repository itself we can cache these steps. For
+# example installing APT packages.
+USER root
+RUN chown -R ${NB_USER}:${NB_USER} ${REPO_DIR}
+
+"""
+
+APT = r"""
+RUN apt-get -qq update && \
+apt-get install --yes --no-install-recommends {} && \
+apt-get -qq purge && \
+apt-get -qq clean && \
+rm -rf /var/lib/apt/lists/*
+
+"""
+
+PIP = r"""
+USER ${{NB_USER}}
+RUN ${{KERNEL_PYTHON_PREFIX}}/bin/pip install --no-cache-dir {}
+
+"""
+
+CONDA = r"""USER root
+RUN chown -R ${{NB_USER}}:${{NB_USER}} ${{REPO_DIR}}
+USER ${{NB_USER}}
+RUN conda install -p ${{NB_PYTHON_PREFIX}} {} && \
+conda clean --all -f -y && \
+conda list -p ${{NB_PYTHON_PREFIX}}
+
+"""
+
+FOOTER = r"""
+# Container image Labels!
+# Put these at the end, since we don't want to rebuild everything
+# when these change! Did I mention I hate Dockerfile cache semantics?
+
+LABEL repo2docker.ref="None"
+LABEL repo2docker.repo="local"
+LABEL repo2docker.version="0.11.0"
+
+USER root
+
+# Add start script
+# Add entrypoint
+RUN ( echo '#!/bin/bash -l' && \
+echo '# lightest possible entrypoint that ensures that' && \
+echo '# we use a login shell to get a fully configured shell environment' && \
+echo '# (e.g. sourcing /etc/profile.d, ~/.bashrc, and friends)' && \
+echo 'if [[ ! -z "${R2D_ENTRYPOINT:-}" ]]; then' && \
+echo '    exec "$R2D_ENTRYPOINT" "$@"' && \
+echo else && \
+echo '    exec "$@"' && \
+echo fi ) > /usr/local/bin/repo2docker-entrypoint && \
+chmod a+x /usr/local/bin/repo2docker-entrypoint
+
+# We always want containers to run as non-root
+USER ${NB_USER}
+
+ENTRYPOINT ["/usr/local/bin/repo2docker-entrypoint"]
+
+# Specify the default command to run
+CMD ["jupyter", "notebook", "--ip", "0.0.0.0"]
+"""
+
+
+def emit_apt(apt_pkgs):
+    if not apt_pkgs:
+        return ''
+    return APT.format(' '.join([shlex.quote(x) for x in apt_pkgs]))
+
+
+def emit_conda(conda_pkgs):
+    if not conda_pkgs:
+        return ''
+    return CONDA.format(' '.join([shlex.quote(x) for x in conda_pkgs]))
+
+
+def emit_pip(pip_pkgs):
+    if not pip_pkgs:
+        return ''
+    return PIP.format(' '.join([shlex.quote(x) for x in pip_pkgs]))
+
+
+def emit_dockerfile(apt_pkgs, conda_pkgs, pip_pkgs):
+    return HEADER + emit_apt(apt_pkgs or []) + emit_conda(conda_pkgs or []) + emit_pip(pip_pkgs or []) + FOOTER

--- a/funcx_container_service/landlord.py
+++ b/funcx_container_service/landlord.py
@@ -1,0 +1,65 @@
+from sqlalchemy import and_, func
+from . import database, build
+from .models import ContainerSpec, ContainerState
+
+
+MAX_STORAGE = None
+ALPHA = 0.5
+
+
+def jaccard(a, b):
+    return 1 - float(len(a & b))/len(a | b)
+
+
+def spec_to_set(spec):
+    out = set()
+    if spec.apt:
+        out.update({f'a{x}' for x in spec.apt})
+    if spec.conda:
+        out.update({f'c{x}' for x in spec.conda})
+    if spec.pip:
+        out.update({f'p{x}' for x in spec.pip})
+    return out
+
+
+def total_storage():
+    with database.session_scope() as session:
+        size = session.query(database.Container).with_entities(
+                func.sum(database.Container.docker_size
+                         + database.Container.singularity_size)).scalar()
+        return size or 0
+
+
+async def cleanup(db):
+    if MAX_STORAGE is None:
+        return
+    while total_storage() > MAX_STORAGE:
+        container = db.query(database.Container).filter(
+                database.Container.docker_size.isnot(None)
+                ).order_by(database.Container.last_used.asc()).first()
+        await build.remove(db, container.id)
+        db.commit()
+
+
+async def find_existing(db, spec):
+    if spec is None:
+        return
+
+    target = spec_to_set(spec)
+    best = None
+    best_distance = 2.0  # greater than any jaccard distance, effectively inf.
+
+    for container in db.query(database.Container).filter(and_(
+            database.Container.state == ContainerState.ready,
+            database.Container.specification.isnot(None))):
+        other = spec_to_set(ContainerSpec.parse_raw(container.specification))
+        if not target.issubset(other):
+            continue
+        distance = jaccard(target, other)
+        if distance > ALPHA:
+            continue
+        if distance < best_distance:
+            best_distance = distance
+            best = container
+
+    return best

--- a/funcx_container_service/models.py
+++ b/funcx_container_service/models.py
@@ -1,0 +1,51 @@
+import json
+import hashlib
+from datetime import datetime
+from enum import Enum
+from uuid import UUID
+from typing import Optional, List
+from pydantic import BaseModel, constr
+
+
+class ContainerState(str, Enum):
+    pending = 'pending'
+    building = 'building'
+    ready = 'ready'
+    failed = 'failed'
+
+
+class ContainerSpec(BaseModel):
+    """Software specification for a container.
+
+    Accepts the following software requirements:
+    - `apt`: list of package names to be installed via apt-get
+    - `pip`: list of pip requirements (name and optional version specifier)
+    - `conda`: list of conda requirements (name and optional version specifier)
+
+    To specify the version of Python to use, include it in the
+    `conda` package list.
+    """
+
+    # regex borrowed from repo2docker (sort of...)
+    # https://github.com/jupyterhub/repo2docker/blob/560b1d96a0e39cb8de53cb41a7c2d8d23384eb82/repo2docker/buildpacks/base.py#L675
+    apt: Optional[List[constr(regex=r'^[a-z0-9.+-]+$')]]  # noqa: F722
+    pip: Optional[List[str]]
+    conda: Optional[List[str]]
+
+    def digest(self):
+        tmp = self.dict()
+        for k, v in tmp.items():
+            if v:
+                v.sort()
+        canonical = json.dumps(tmp, sort_keys=True)
+        return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+class StatusResponse(BaseModel):
+    """API response giving a container's status"""
+    id: UUID
+    status: ContainerState
+    recipe_checksum: str
+    last_used: datetime
+    docker_size: Optional[int]
+    singularity_size: Optional[int]

--- a/funcx_container_service/resources/environments.py
+++ b/funcx_container_service/resources/environments.py
@@ -1,6 +1,0 @@
-from flask_restful import Resource
-
-
-class Environments(Resource):
-    def get(self):
-        return "TODO :)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-click==7.1.2
-Flask==1.1.2
-Flask-RESTful==0.3.8
-itsdangerous==1.1.0
-Jinja2==2.11.2
-MarkupSafe==1.1.1
-Werkzeug==1.0.1
+jupyter-repo2docker
+fastapi[all]
+python-multipart
+uvicorn
+SQLAlchemy
+docker
+boto3

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,2 @@
-flake8>=3.8
-pytest>=5.2
-pytest-flask==1.0.0
+flake8
+pytest

--- a/tests/resources/test_container_service.py
+++ b/tests/resources/test_container_service.py
@@ -1,23 +1,3 @@
-from funcx_container_service import create_app
-from funcx_container_service.config import TestConfig
-
-import pytest
-
-
 class TestContainerService:
-    @pytest.fixture
-    def client(self):
-        return create_app(app_config_object=TestConfig).test_client()
-
-    def test_create_environment(self, client):
-        assert True
-
-    def test_delete_environment(self, client):
-        assert True
-
-    def test_get_environment(self, client):
-        resp = client.get("/environments")
-        assert resp.status_code == 200
-
-    def test_update_environment(self, client):
+    def test_create_environment(self):
         assert True

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,8 +1,0 @@
-[uwsgi]
-uid = uwsgi
-binary-path = /usr/local/bin/uwsgi
-plugins = python37
-protocol = uwsgi
-http = 0.0.0.0:5000
-manage-script-name = true
-module = funcx_container_service.application:app

--- a/web-entrypoint.sh
+++ b/web-entrypoint.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-uwsgi --ini uwsgi.ini


### PR DESCRIPTION
Provides core functionality for the Container Service
- Build Docker and Singularity images
- Accept JSON package lists or repo2docker tarballs (advanced)
- Deduplicate identical container requests
- Basic Landlord trickery (use compatible container if available instead of building)
- Limit storage for cached containers
- Lazy building/rebuilding of containers from spec/tarball

Still has some work needed to get deployed
- Integration with the rest of FuncX is needed (Globus auth on API, setting up endpoints to ask for containers, etc.)
- DB connection and AWS credentials (S3 and ECR) need to be passed in
- Docker and Singularity maintain their own local caches (which are important to avoid repeated work on common base layers). These need to be cleaned periodically.
- Both Docker and Singularity need to be installed to build. We can bind the Docker control socket in, and need to decide on a container environment that works with Singularity (packages in EPEL, or build from source)