### PR TITLE
Restore docker push

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,3 +46,10 @@ jobs:
       shell: bash
       run: echo "##[set-output name=imagetag;]$(echo ${GITHUB_REF##*/})"
       id: extract_tag_name
+    - name: Build funcX-container-service Image
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: funcx/container-service:${{ steps.extract_tag_name.outputs.imagetag }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        tag: "${GITHUB_REF##*/}"

--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,16 @@
-FROM python:3.7-alpine
-RUN apk update && \
-    apk add --no-cache gcc musl-dev linux-headers && \
-    apk add postgresql-dev libffi-dev g++ make libressl-dev git
+FROM python:3.7
+RUN apt-get update && \
+    apt-get install -y  gcc musl-dev && \
+    apt-get install -y  postgresql libffi-dev g++ make git
 
-# Create a group and user
-RUN addgroup -S http && adduser -S http -G http
+RUN addgroup http && useradd http -g http
 
 WORKDIR /opt/
 
-COPY ./requirements.txt /tmp/
-RUN pip install -r /tmp/requirements.txt
+COPY ./requirements.txt .
+RUN pip install -r ./requirements.txt
 
-COPY ./funcx_container_service/ ./
+COPY ./funcx_container_service/ ./funcx_container_service/
 
 USER http
 EXPOSE 5000


### PR DESCRIPTION
# Problem
The GitHub Action is no longer publishing a docker image. Upon closer inspection, the Dockerfile itself was no longer working.

Partial solution to #9 

# Approach
One of the pip installs failed due to the image being based on the alpine O/S. This image doesn't support a number of pypi installs. Migrated the base image to Buster which required some changes to the package install and user management commands.

Restored the docker build to the CI pipeline and all is well