### PR TITLE
Adding version route

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,14 +33,10 @@ jobs:
         pip freeze | safety check
     - name: Lint with Flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        # flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
         flake8 --max-line-length=120
     - name: Test with pytest
       run: |
-        python -m pytest
+        python -m pytest -m "not integration_test"
   publish:
     needs: test
     runs-on: ubuntu-latest

--- a/funcx_container_service/__init__.py
+++ b/funcx_container_service/__init__.py
@@ -1,7 +1,6 @@
 from uuid import uuid4
 from functools import lru_cache
 from pprint import pformat
-import pdb
 
 from logging.config import dictConfig
 import logging

--- a/funcx_container_service/__init__.py
+++ b/funcx_container_service/__init__.py
@@ -1,6 +1,7 @@
 from uuid import uuid4
 from functools import lru_cache
 from pprint import pformat
+import pdb
 
 from logging.config import dictConfig
 import logging
@@ -12,6 +13,7 @@ from . import callback_router
 from .container import Container
 from .models import ContainerSpec
 from .config import Settings
+from .version import container_service_version
 
 
 dictConfig(LogConfig().dict())
@@ -73,6 +75,5 @@ async def read_main():
 
 
 @app.get("/version")
-async def version():
-    version = "0.1"
-    return {"version": version}
+async def get_version():
+    return {"version": container_service_version}

--- a/funcx_container_service/__init__.py
+++ b/funcx_container_service/__init__.py
@@ -70,3 +70,9 @@ async def simple_build(spec: ContainerSpec,
 @app.get("/")
 async def read_main():
     return {"msg": "Hello World"}
+
+
+@app.get("/version")
+async def version():
+    version = "0.1"
+    return {"version": version}

--- a/funcx_container_service/version.py
+++ b/funcx_container_service/version.py
@@ -1,0 +1,1 @@
+container_service_version = "1.0"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers = 
+	integration_test: marks tests for integration testing (vs unit testing)

--- a/tests/resources/test_build.py
+++ b/tests/resources/test_build.py
@@ -60,6 +60,7 @@ def apt_container_spec_fixture():
     return mock_spec
 
 
+@pytest.mark.integration_test
 @pytest.mark.asyncio
 async def test_repo2docker_build(container_id_fixture, temp_dir_fixture):
     print(f'building container id: {container_id_fixture}')
@@ -70,6 +71,7 @@ async def test_repo2docker_build(container_id_fixture, temp_dir_fixture):
     remove_image(container_id_fixture)
 
 
+@pytest.mark.integration_test
 @pytest.mark.asyncio
 async def test_empty_build_from_spec(container_id_fixture,
                                      blank_container_spec_fixture,
@@ -84,6 +86,7 @@ async def test_empty_build_from_spec(container_id_fixture,
     remove_image(container_id_fixture)
 
 
+@pytest.mark.integration_test
 @pytest.mark.asyncio
 async def test_pip_build_from_spec(container_id_fixture,
                                    pip_container_spec_fixture,
@@ -98,6 +101,7 @@ async def test_pip_build_from_spec(container_id_fixture,
     remove_image(container_id_fixture)
 
 
+@pytest.mark.integration_test
 @pytest.mark.asyncio
 async def test_apt_build_from_spec(container_id_fixture,
                                    apt_container_spec_fixture,

--- a/tests/resources/test_routes.py
+++ b/tests/resources/test_routes.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+from funcx_container_service.__init__ import app
+
+client = TestClient(app)
+
+
+def test_read_main():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"msg": "Hello World"}
+
+
+def test_read_verion():    
+    response = client.get("/version")
+    # pdb.set_trace()
+    assert response.status_code == 200
+    assert response.json()["version"] is not None

--- a/tests/resources/test_routes.py
+++ b/tests/resources/test_routes.py
@@ -10,7 +10,7 @@ def test_read_main():
     assert response.json() == {"msg": "Hello World"}
 
 
-def test_read_verion():    
+def test_read_verion():
     response = client.get("/version")
     # pdb.set_trace()
     assert response.status_code == 200


### PR DESCRIPTION
As described in issue #14, a route has been implemented at `/version` that when accessed returns the json message `{"version": container_service_version}`, where `container_service_version` is populated via the `version.py` file.

Note that this pull request also includes:
- tagging of build tests using `@pytest.mark.integration_test` 
- the inclusion of a `pytest.ini` to define the custom pytest mark
- a change to the github action in `ci.yaml` to skip tests with that mark