### PR TITLE
Image 2 registry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,14 +33,10 @@ jobs:
         pip freeze | safety check
     - name: Lint with Flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        # flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
         flake8 --max-line-length=120
     - name: Test with pytest
       run: |
-        python -m pytest
+        python -m pytest -m "not integration_test"
   publish:
     needs: test
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,10 @@ WORKDIR /opt/
 COPY ./requirements.txt .
 RUN pip install -r ./requirements.txt
 
+COPY main.py ./main.py
 COPY ./funcx_container_service/ ./funcx_container_service/
 
 USER http
-EXPOSE 5000
+EXPOSE 8000
 
-CMD uvicorn funcx_container_service:app --host '0.0.0.0' --port 5000
+CMD PYTHONPATH=./funcx_container_service python main.py

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The Container service runs in a container using FastAPI. It's
 responsible for creating and managing container environments for running
 functions on funcX.
 
+## Configuring the service
+
 A configuration file (titled '.env') is required at the top level of the
 repository which houses the configuration settings necessary to run
 the serivce. This file uses the VAR=VAL syntax and currently requires the
@@ -11,7 +13,16 @@ following VARs defined:
 
 ```
 WEBSERVICE_URL=<url for the webserivce that issues requests to the container service>
+REGISTRY_USERNAME=<registry username>
+REGISTRY_PWD=<registry password>
+REGISTRY_URL=<url to registry>
 ```
+`WEBSERVICE_URL` is the webservice for the funcx service that registers the user submission for a container build via the sdk
+
+The `REGISTRY` variables define the access information for the registry to which the resulting image built by the container service should be stored
+
+
+## Running the service
 
 ## Development Setups
 For the full container service experience you will want a local instance of the

--- a/README.md
+++ b/README.md
@@ -13,6 +13,75 @@ following VARs defined:
 WEBSERVICE_URL=<url for the webserivce that issues requests to the container service>
 ```
 
+## Development Setups
+For the full container service experience you will want a local instance of the
+funcX webservice running, along with a compatible version of the funcX SDK.
+
+### Install the container_service branch of the sdk:
+In a clean virtual environment install the container service development 
+branch of the funcX SDK
+```shell
+pip install git+https://github.com/funcx-faas/funcX.git@container_service#subdirectory=funcx_sdk
+```
+
+### Run the Container Service
+There are two options for running the container service. If you just need it
+to be available, you can run a published docker image:
+```shell
+docker run --rm -it --env WEBSERVICE_URL=http://host.docker.internal:5000 -p 8000:8000 funcx/container-service:dev
+```
+This uses a macOS Docker feature for accessing the host's ports from within a 
+docker container.
+
+For development and debugging purposes, you can run the Container Service in
+pyCharm or other IDE. For this, setup a runtime configuration that runs the 
+script `main.py`. You will need to provide an environment variable to the 
+process that sets `WEBSERVICE_URL=http://localhost:5000`
+
+### Run the FuncX Web Service
+Likewise, there are the same two options for running the web service. If you
+just want to run the webservice you can use the container_service tagged 
+image. In this case, you need to provide the service with a config file. A 
+working config file is checked into _this_ repo, `web_svc_app.conf`. This 
+gets mounted into the container and run as:
+```shell
+docker run --rm -it -p 5000:5000 \
+       --mount "type=bind,source=$(pwd)/web_svc_app.conf,target=/opt/app.conf" \
+       --env APP_CONFIG_FILE=/opt/app.conf \
+       funcx/web-service:container_service
+```
+
+For development and debugging you can run the web service in pyCharm. That
+IDE directly supports flask apps. Just add an environment variable,
+```
+APP_CONFIG_FILE=../funcx-container-service/web_svc_app.conf
+```
+The web app will be running on port 5000 and expecting the container service 
+on port 8000.
+
+### Taking the Container Service out for a Spin
+With the container service enabled SDK, it's easy to submit a container 
+build request:
+```python
+from funcx import ContainerSpec, FuncXClient
+
+fxc = FuncXClient(funcx_service_address="http://localhost:5000/v2")
+container_uuid = fxc.build_container(
+    ContainerSpec(
+        name="MyContainer",
+        apt=[
+            "dvipng",
+            "ghostscript"
+        ],
+        pip=[
+            "cycler==0.10.0"
+        ],
+    )
+)
+
+print(f"Building {container_uuid}")
+print(f"status is {fxc.get_container_build_status(container_uuid)}")
+```
 You can run the service inside a docker container.
 
 ```

--- a/README.md
+++ b/README.md
@@ -109,3 +109,18 @@ service will rely on for complete functionality.
 The Docker daemon needs to be running (with the control socket)
 bind mounted into the container if applicable. Also requires Singularity 3.x
 in the build environment.
+
+## Testing
+
+Two types of tests so far;
+	use `pytest -m "not integration_test" tests/resources` to only run
+	unit tests.
+	
+	To run integration tests, start docker as above and use
+	`pytest -m "integration_test" tests/resources`
+	
+	
+	
+
+
+

--- a/funcx_container_service/__init__.py
+++ b/funcx_container_service/__init__.py
@@ -12,6 +12,7 @@ from . import callback_router
 from .container import Container
 from .models import ContainerSpec
 from .config import Settings
+from .version import container_service_version
 
 
 dictConfig(LogConfig().dict())
@@ -70,3 +71,8 @@ async def simple_build(spec: ContainerSpec,
 @app.get("/")
 async def read_main():
     return {"msg": "Hello World"}
+
+
+@app.get("/version")
+async def get_version():
+    return {"version": container_service_version}

--- a/funcx_container_service/__init__.py
+++ b/funcx_container_service/__init__.py
@@ -1,7 +1,6 @@
 from uuid import uuid4
 from functools import lru_cache
 from pprint import pformat
-import pdb
 
 from logging.config import dictConfig
 import logging

--- a/funcx_container_service/__init__.py
+++ b/funcx_container_service/__init__.py
@@ -9,6 +9,7 @@ from .config import LogConfig
 from fastapi import (FastAPI, BackgroundTasks, Depends)
 
 from . import callback_router
+from .build import simple_background_build
 from .container import Container
 from .models import ContainerSpec
 from .config import Settings
@@ -53,9 +54,11 @@ async def simple_build(spec: ContainerSpec,
     container = Container(spec)
 
     # kickoff the build process in the background
-    # tasks.add_task(build.simple_background_build, container)
+    log.info("Starting container build process...")
+    tasks.add_task(simple_background_build, container)
+
     # for integration testing, going to punt on the build and just pretend it kicked off appropriately
-    log.info('STUB: This is where the build process would happen...')
+    # log.info('STUB: This is where the build process would happen...')
 
     # register a build (build_id + container_id) with database and return the build_id
     build_response = await container.register_build(RUN_ID, settings)

--- a/funcx_container_service/__init__.py
+++ b/funcx_container_service/__init__.py
@@ -1,6 +1,7 @@
 from uuid import uuid4
 from functools import lru_cache
 from pprint import pformat
+import pdb
 
 from logging.config import dictConfig
 import logging

--- a/funcx_container_service/build.py
+++ b/funcx_container_service/build.py
@@ -235,15 +235,15 @@ def env_from_spec(spec):
     can build the python environment
     """
 
-    out = {
+    env_content = {
         "name": "funcx-container",
         "channels": ["conda-forge"],
         "dependencies": ["pip"]
     }
     if spec.conda:
         # append conda packages to dependencies list
-        out["dependencies"] += list(spec.conda)
+        env_content["dependencies"] += list(spec.conda)
     if spec.pip:
         # append dict with {pip:[packages]} to dependencies list
-        out["dependencies"].append({"pip": list(spec.pip)})
-    return out
+        env_content["dependencies"].append({"pip": list(spec.pip)})
+    return env_content

--- a/funcx_container_service/build.py
+++ b/funcx_container_service/build.py
@@ -173,6 +173,8 @@ def push_image(image_name, settings):
                                        auth_config=auth_dict):
             log.info(line)
 
+        log.info(f'docker image {image_name} sent to {settings.REGISTRY_USERNAME}/{image_name}:{tag_string}')
+
 
 def s3_connection():
     return boto3.client('s3')

--- a/funcx_container_service/build.py
+++ b/funcx_container_service/build.py
@@ -104,7 +104,7 @@ async def repo2docker_build(container_id, temp_dir):
     collect the resulting log information
     """
 
-    completion_spec = BuildCompetionSpec()
+    completion_spec = BuildCompletionSpec()
     completion_spec.container_id = container_id
     completion_spec.repo2docker_return_code = 0
 

--- a/funcx_container_service/build.py
+++ b/funcx_container_service/build.py
@@ -8,7 +8,6 @@ from uuid import UUID
 
 from pathlib import Path
 from docker.errors import ImageNotFound
-import docker
 
 from .models import ContainerSpec
 from .container import Container, ContainerState
@@ -30,9 +29,118 @@ class Build():
     # container = relationship('Container', back_populates='builds')
 
 
+async def simple_background_build(container: Container,
+                                  settings: Settings,
+                                  RUN_ID: UUID):
+    """
+    Most basic of build processes passed to a task through route activation.
+    Start by checking state of build from the webservice. If status is
+    appropriate (as indicated by container.start_build()) proceed to construct
+    the container using repo2docker, push image to specified registry,
+    and update webservice upon successful completion
+
+    :param Container container: The Container object instance
+    :param Settings settings: Settings object with required metadata
+    :param UUID RUN_ID: unique identifier of the instance of this container building service
+    """
+
+    # check container.container_state to see if we should build
+    if container.start_build(RUN_ID, settings):
+
+        docker_client = docker.APIClient(base_url=DOCKER_BASE_URL)
+        try:
+
+            with tempfile.TemporaryDirectory() as tmp:
+                tmp = Path(tmp)
+
+                # write spec to file
+                if container.container_spec:
+                    await build_spec_to_file(
+                        container.container_id,
+                        ContainerSpec.parse_raw(container.container_spec),
+                        tmp)
+
+                    # build container with docker
+                    result_dict = await repo2docker_build(container.container_id, tmp)
+
+                    # check for failed build
+                    if result_dict['returncode'] != 0:
+                        container.state = ContainerState.failed
+                        return
+
+                    container.container_size = result_dict['container_size']
+
+                    # on successful build, push container to registry
+                    image_name = docker_name(container.container_id)
+                    push_image(image_name, settings)
+
+                    # update container state upon successful build
+                    container.state = ContainerState.ready
+
+        finally:
+
+            result_dict['docker_client_version'] = docker_client.version()
+            result_dict['RUN_ID'] = RUN_ID
+            result_dict['conatiner_state'] = container.state
+
+        container.register_build_complete(result_dict, settings)
+
+
+async def build_spec_to_file(container_id, spec, tmp_dir):
+    """
+    Write the build specifications out to a file in the temp directory that can
+    be accessed by repo2docker for the build process
+    """
+    if spec.apt:
+        with (tmp_dir / 'apt.txt').open('w') as f:
+            f.writelines([x + '\n' for x in spec.apt])
+    with (tmp_dir / 'environment.yml').open('w') as f:
+        json.dump(env_from_spec(spec), f, indent=4)
+
+
+async def repo2docker_build(container_id, temp_dir):
+    """
+    Pass the file with the build specs to repo2docker to create the build and
+    collect the resulting log information
+    """
+
+    build_response = {}
+    build_response['container_id'] = container_id
+    build_response['repo2docker_return_code'] = 0
+
+    process = await asyncio.create_subprocess_shell(REPO2DOCKER_CMD.format(docker_name(container_id), temp_dir),
+                                                    stdout=asyncio.subprocess.PIPE,
+                                                    stderr=asyncio.subprocess.PIPE)
+
+    stdout = await process.stdout.read()
+    stderr = await process.stderr.read()
+
+    if stdout.decode():
+        stdout_msg = stdout.decode()
+        logging.info(f'REPO2DOCKER: {stdout_msg}')
+        build_response['stdout'] = stdout_msg
+
+    if stderr.decode():
+        err_msg = stderr.decode()
+        logging.error(f'REPO2DOCKER: {err_msg}')
+        build_response['stderr'] = err_msg
+
+    await process.wait()
+
+    if process.returncode != 0:
+        logging.error(f'Return code {process.returncode} produced while running \
+            repo2docker for container_id: {container_id}')
+
+        build_response['repo2docker_return_code'] = process.returncode
+
+    build_response['container_size'] = docker_size(container_id)
+
+    return build_response
+
+
 def push_image(image_name, settings):
     docker_client = docker.DockerClient(base_url=DOCKER_BASE_URL)
-    d_response = docker_client.login(username=settings.REGISTRY_USERNAME, 
+    d_response = docker_client.login(username=settings.REGISTRY_USERNAME,
                                      password=settings.REGISTRY_PWD,
                                      registry=settings.REGISTRY_URL)
 
@@ -89,117 +197,20 @@ def docker_size(container_id):
 
 
 def env_from_spec(spec):
+    """
+    create content for environment.yml to be passed to repo2docker so conda
+    can build the python environment
+    """
+
     out = {
         "name": "funcx-container",
         "channels": ["conda-forge"],
         "dependencies": ["pip"]
     }
     if spec.conda:
+        # append conda packages to dependencies list
         out["dependencies"] += list(spec.conda)
     if spec.pip:
+        # append dict with {pip:[packages]} to dependencies list
         out["dependencies"].append({"pip": list(spec.pip)})
     return out
-
-
-async def simple_background_build(container: Container,
-                                  settings: Settings,
-                                  RUN_ID: UUID):
-    """
-    Most basic of build processes passed to a task through route activation.
-    Start by checking state of build from the webservice. If status is
-    appropriate (as indicated by container.start_build()) proceed to construct
-    the container using repo2docker
-
-    :param Container container: The Container object instance
-    :param Settings settings: Settings object with required metadata
-    :param UUID RUN_ID: unique identifier of the instance of this container building service
-    """
-
-    # check container.container_state to see if we should build
-    if container.start_build(RUN_ID, settings):
-
-        docker_client = docker.APIClient(base_url=DOCKER_BASE_URL)
-        try:
-            # build container with docker
-            container.docker_size = await docker_simple_build(container)
-            if container.docker_size is None:
-                container.state = ContainerState.failed
-                # TODO: capture and return output from docker_client.version()
-                return
-
-            # on successful build, push container to registry
-            await asyncio.to_thread(docker_client.push,
-                                    docker_name(container.container_id))
-            container.state = ContainerState.ready
-
-        finally:
-            container.builder = None
-            # TODO: update container status w/ webservice via callback_router.py
-            pass
-
-
-async def docker_simple_build(container):
-    with tempfile.TemporaryDirectory() as tmp:
-        tmp = Path(tmp)
-        if container.specification:
-            container_size = await build_spec(
-                    container.container_id,
-                    ContainerSpec.parse_raw(container.specification),
-                    tmp)
-        # else:
-        #     if not tarball:
-        #         download = tempfile.NamedTemporaryFile()
-        #         tarball = download.name
-        #         await asyncio.to_thread(
-        #                 s3.download_file, 'repos', container.id, tarball)
-        #     container_size = await build_tarball(
-        #             s3,
-        #             container.id,
-        #             tarball,
-        #             tmp)
-        #     # just to be safe
-        #     os.unlink(tarball)
-    return container_size
-
-
-async def build_spec(container_id, spec, tmp_dir):
-    """
-    Write the build specifications out to a file in the temp directory that can
-    be accessed by repo2docker for the build process
-    """
-    if spec.apt:
-        with (tmp_dir / 'apt.txt').open('w') as f:
-            f.writelines([x + '\n' for x in spec.apt])
-    with (tmp_dir / 'environment.yml').open('w') as f:
-        json.dump(env_from_spec(spec), f, indent=4)
-    return await repo2docker_build(container_id, tmp_dir)
-
-
-async def repo2docker_build(container_id, temp_dir):
-    """
-    Pass the file with the build specs to repo2docker to create the build and
-    collect the resulting log information
-    """
-
-    process = await asyncio.create_subprocess_shell(
-            REPO2DOCKER_CMD.format(docker_name(container_id), temp_dir),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE)
-
-    stdout = await process.stdout.read()
-    stderr = await process.stderr.read()
-
-    if stdout.decode():
-        logging.info(f'REPO2DOCKER: {stdout.decode()}')
-    if stderr.decode():
-        logging.error(f'REPO2DOCKER: {stderr.decode()}')
-
-    await process.wait()
-
-    if process.returncode != 0:
-        logging.error(f'Return code {process.returncode} produced while running \
-            repo2docker for container_id: {container_id}')
-        return None
-
-    container_size = docker_size(container_id)
-    return container_size

--- a/funcx_container_service/callback_router.py
+++ b/funcx_container_service/callback_router.py
@@ -62,7 +62,7 @@ def register_container_spec_requests(spec: ContainerSpec,
     return container_id
 
 
-@build_callback_router.put(f'<webservice_url>/v2/containers/<container_id>/status')
+@build_callback_router.put('<webservice_url>/v2/containers/<container_id>/status')
 def register_build(body: BuildSpec):
     pass
 
@@ -88,7 +88,7 @@ async def register_building(container: Container, settings: Settings):
     return response
 
 
-@build_callback_router.put(f'<webservice_url>/v2/containers/<container_id>/status')
+@build_callback_router.put('<webservice_url>/v2/containers/<container_id>/status')
 def register_build_start(body: BuildSpec):
     pass
 
@@ -112,7 +112,7 @@ async def register_build_starting(container: Container, settings: Settings):
             log.error(f"register build complete sent back {response}")
 
 
-@build_callback_router.put(f'<webservice_url>/v2/containers/<container_id>/status')
+@build_callback_router.put('<webservice_url>/v2/containers/<container_id>/status')
 def register_build_completion(body: BuildCompletionSpec):
     pass
 

--- a/funcx_container_service/callback_router.py
+++ b/funcx_container_service/callback_router.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 import httpx
 
 from .config import Settings
-from .models import ContainerSpec, BuildSpec
+from .models import ContainerSpec, BuildSpec, BuildCompletionSpec
 
 
 log = logging.getLogger("funcx_container_service")
@@ -61,8 +61,8 @@ def register_container_spec_requests(spec: ContainerSpec,
     return container_id
 
 
-@build_callback_router.post(f'{Settings().WEBSERVICE_URL.strip("/")}/register_build')
-def store_build_spec(body: BuildSpec):
+@build_callback_router.put(f'{Settings().WEBSERVICE_URL.strip("/")}/v2/containers/[container_id]/status')
+def register_build_start(body: BuildSpec):
     pass
 
 
@@ -87,7 +87,7 @@ async def register_build(build_spec: BuildSpec, settings: Settings):
     async with httpx.AsyncClient() as client:
         response = await client.put(urljoin(
             settings.WEBSERVICE_URL,
-            f"v2/containers/build/{build_spec.container_id}"),
+            f"v2/containers/{build_spec.container_id}/status"),
             json=build_dict)
 
         if response.status_code != 200:
@@ -102,13 +102,17 @@ async def register_build(build_spec: BuildSpec, settings: Settings):
     return response
 
 
-async def register_build_complete(post_dict, settings: Settings):
+@build_callback_router.put(f'{Settings().WEBSERVICE_URL.strip("/")}/v2/containers/[container_id]/status')
+def register_build_complete(body: BuildCompletionSpec):
+    pass
+
+async def register_build_complete(completion_spec, settings: Settings):
 
     async with httpx.AsyncClient() as client:
         response = await client.put(urljoin(
             settings.WEBSERVICE_URL,
-            f"v2/containers/build_complete/{post_dict['container_id']}"),
-            json=post_dict)
+            f"v2/containers/{completion_spec.container_id}/status"),
+            json=completion_spec)
 
         if response.status_code != 200:
             log.error(f"register build complete sent back {response}")

--- a/funcx_container_service/callback_router.py
+++ b/funcx_container_service/callback_router.py
@@ -62,7 +62,7 @@ def register_container_spec_requests(spec: ContainerSpec,
     return container_id
 
 
-@build_callback_router.put(f'{Settings().WEBSERVICE_URL.strip("/")}/v2/containers/[container_id]/status')
+@build_callback_router.put(f'<webservice_url>/v2/containers/<container_id>/status')
 def register_build(body: BuildSpec):
     pass
 
@@ -88,7 +88,7 @@ async def register_building(container: Container, settings: Settings):
     return response
 
 
-@build_callback_router.put(f'{Settings().WEBSERVICE_URL.strip("/")}/v2/containers/[container_id]/status')
+@build_callback_router.put(f'<webservice_url>/v2/containers/<container_id>/status')
 def register_build_start(body: BuildSpec):
     pass
 
@@ -112,7 +112,7 @@ async def register_build_starting(container: Container, settings: Settings):
             log.error(f"register build complete sent back {response}")
 
 
-@build_callback_router.put(f'{Settings().WEBSERVICE_URL.strip("/")}/v2/containers/[container_id]/status')
+@build_callback_router.put(f'<webservice_url>/v2/containers/<container_id>/status')
 def register_build_completion(body: BuildCompletionSpec):
     pass
 

--- a/funcx_container_service/callback_router.py
+++ b/funcx_container_service/callback_router.py
@@ -102,5 +102,17 @@ async def register_build(build_spec: BuildSpec, settings: Settings):
     return response
 
 
+async def register_build_complete(post_dict, settings: Settings):
+
+    async with httpx.AsyncClient() as client:
+        response = await client.put(urljoin(
+            settings.WEBSERVICE_URL,
+            f"v2/containers/build_complete/{post_dict['container_id']}"),
+            json=post_dict)
+
+        if response.status_code != 200:
+            log.error(f"register build complete sent back {response}")
+
+
 async def remove_build(container_id):
     pass

--- a/funcx_container_service/callback_router.py
+++ b/funcx_container_service/callback_router.py
@@ -109,7 +109,7 @@ async def register_build_starting(container: Container, settings: Settings):
             json=build_spec.json())
 
         if response.status_code != 200:
-            log.error(f"register build complete sent back {response}")
+            log.error(f"register build start sent back {response}")
 
 
 @build_callback_router.put('<webservice_url>/v2/containers/<container_id>/status')

--- a/funcx_container_service/callback_router.py
+++ b/funcx_container_service/callback_router.py
@@ -10,7 +10,6 @@ from .config import Settings
 from .container import Container
 from .models import ContainerSpec, BuildSpec, BuildCompletionSpec
 
-
 log = logging.getLogger("funcx_container_service")
 
 
@@ -120,6 +119,7 @@ def register_build_completion(body: BuildCompletionSpec):
 async def register_build_complete(completion_spec: BuildCompletionSpec, settings: Settings):
 
     async with httpx.AsyncClient() as client:
+        log.info(f'updating status with message: {pformat(completion_spec)}')
         response = await client.put(urljoin(
             settings.WEBSERVICE_URL,
             f"v2/containers/{completion_spec.container_id}/status"),

--- a/funcx_container_service/callback_router.py
+++ b/funcx_container_service/callback_router.py
@@ -103,8 +103,9 @@ async def register_build(build_spec: BuildSpec, settings: Settings):
 
 
 @build_callback_router.put(f'{Settings().WEBSERVICE_URL.strip("/")}/v2/containers/[container_id]/status')
-def register_build_complete(body: BuildCompletionSpec):
+def register_build_completion(body: BuildCompletionSpec):
     pass
+
 
 async def register_build_complete(completion_spec, settings: Settings):
 

--- a/funcx_container_service/config.py
+++ b/funcx_container_service/config.py
@@ -6,6 +6,9 @@ class Settings(BaseSettings):
     app_name: str = "FuncxContainerService"
     WEBSERVICE_URL: str = ""
     admin_email: Optional[str] = None
+    REGISTRY_USERNAME: str
+    REGISTRY_PWD: str
+    REGISTRY_URL: str
     # def __init__(self):
     #     config = dotenv_values(".env")
     #     pdb.set_trace()

--- a/funcx_container_service/config.py
+++ b/funcx_container_service/config.py
@@ -6,9 +6,9 @@ class Settings(BaseSettings):
     app_name: str = "FuncxContainerService"
     WEBSERVICE_URL: str = ""
     admin_email: Optional[str] = None
-    REGISTRY_USERNAME: str
-    REGISTRY_PWD: str
-    REGISTRY_URL: str
+    REGISTRY_USERNAME: Optional[str] = None
+    REGISTRY_PWD: Optional[str] = None
+    REGISTRY_URL: Optional[str] = None
     # def __init__(self):
     #     config = dotenv_values(".env")
     #     pdb.set_trace()

--- a/funcx_container_service/config.py
+++ b/funcx_container_service/config.py
@@ -9,10 +9,6 @@ class Settings(BaseSettings):
     REGISTRY_USERNAME: Optional[str] = None
     REGISTRY_PWD: Optional[str] = None
     REGISTRY_URL: Optional[str] = None
-    # def __init__(self):
-    #     config = dotenv_values(".env")
-    #     pdb.set_trace()
-    #     self.webservice_url = config['WEBSERVICE_URL']
 
     class Config:
         env_prefix = ''

--- a/funcx_container_service/container.py
+++ b/funcx_container_service/container.py
@@ -36,7 +36,7 @@ class Container():
     async def register(self, settings):
         self.container_id = await callback_router.register_container_spec(self.container_spec, settings)
 
-    async def register_build(self, RUN_ID, settings):
+    async def register_building(self, RUN_ID, settings):
         build_result = await callback_router.register_building(self,
                                                                settings)
         return build_result

--- a/funcx_container_service/container.py
+++ b/funcx_container_service/container.py
@@ -1,6 +1,6 @@
 import uuid
 from . import callback_router
-from .models import BuildSpec, ContainerSpec, ContainerState, BuildCompletionSpec
+from .models import BuildSpec, ContainerSpec, ContainerState
 
 
 class Container():

--- a/funcx_container_service/container.py
+++ b/funcx_container_service/container.py
@@ -1,6 +1,6 @@
 import uuid
 from . import callback_router
-from .models import BuildSpec, ContainerSpec, ContainerState
+from .models import ContainerSpec, ContainerState
 
 
 class Container():
@@ -11,10 +11,12 @@ class Container():
     deployed on the funcX service for inference.
     """
 
-    def __init__(self, container_spec: ContainerSpec):
+    def __init__(self, container_spec: ContainerSpec, RUN_ID):
         self.container_spec = container_spec
         self.container_id = container_spec.container_id
-        self.build_status = None
+        self.build_id = str(uuid.uuid4())
+        self.RUN_ID = RUN_ID
+        self.build_status = ContainerState.pending
         self.container_state = None
         self.container_build_process = None
         self.build_spec = None
@@ -35,15 +37,8 @@ class Container():
         self.container_id = await callback_router.register_container_spec(self.container_spec, settings)
 
     async def register_build(self, RUN_ID, settings):
-        build_id = str(uuid.uuid4())
-        build_spec = BuildSpec(container_id=self.container_id,
-                               build_id=build_id,
-                               RUN_ID=RUN_ID)
-
-        self.build_spec = build_spec
-
-        build_result = await callback_router.register_build(build_spec,
-                                                            settings)
+        build_result = await callback_router.register_building(self,
+                                                               settings)
         return build_result
 
     async def register_build_complete(self, completion_spec, settings):
@@ -55,27 +50,24 @@ class Container():
         return build_complete_result
 
     def start_build(self, RUN_ID, settings):
-        try:
-            if self.container_state == ContainerState.ready:
-                # nothing to do
-                return False
-            elif self.container_state == ContainerState.failed:
-                # already failed, not going to change
-                return False
-            elif (self.container_state == ContainerState.building and self.container_build_process == RUN_ID):
-                # build already started by this server
-                return False
-            elif self.container_state == ContainerState.building:
-                # build from a previous (crashed) server, clean up
-                # await build.remove(db, container_id)
 
-                # TODO: removed due to circular import, but what does this do?
-                # build.remove(self.container_id)
-                pass
+        if self.container_state == ContainerState.ready:
+            # nothing to do
+            return False
+        elif self.container_state == ContainerState.failed:
+            # already failed, not going to change
+            return False
+        elif (self.container_state == ContainerState.building and self.container_build_process == RUN_ID):
+            # build already started by this server
+            return False
+        elif self.container_state == ContainerState.building:
+            # build from a previous (crashed) server, clean up
+            # await build.remove(db, container_id)
 
-            self.container_state = ContainerState.building
-            self.container_build_process = RUN_ID
-            return True
+            # TODO: removed due to circular import, but what does this do?
+            # build.remove(self.container_id)
+            pass
 
-        finally:
-            callback_router.update_container(self, settings)
+        self.container_state = ContainerState.building
+        self.container_build_process = RUN_ID
+        return True

--- a/funcx_container_service/container.py
+++ b/funcx_container_service/container.py
@@ -1,6 +1,6 @@
 import uuid
 from . import callback_router
-from .models import ContainerSpec, ContainerState
+from .models import ContainerSpec, BuildStatus
 
 
 class Container():
@@ -16,17 +16,15 @@ class Container():
         self.container_id = container_spec.container_id
         self.build_id = str(uuid.uuid4())
         self.RUN_ID = RUN_ID
-        self.build_status = ContainerState.pending
-        self.container_state = None
+        self.build_status = BuildStatus.pending
         self.container_build_process = None
         self.build_spec = None
-        self.container_state = ContainerState.pending
 
     """
     from definition of container object in database.py:
     id = Column(String, primary_key=True)
     last_used = Column(DateTime)
-    state = Column(Enum(ContainerState))
+    state = Column(Enum(BuildStatus))
     specification = Column(String)
     docker_size = Column(Integer)
     singularity_size = Column(Integer)
@@ -51,16 +49,16 @@ class Container():
 
     def start_build(self, RUN_ID, settings):
 
-        if self.container_state == ContainerState.ready:
+        if self.build_status == BuildStatus.complete:
             # nothing to do
             return False
-        elif self.container_state == ContainerState.failed:
+        elif self.build_status == BuildStatus.failed:
             # already failed, not going to change
             return False
-        elif (self.container_state == ContainerState.building and self.container_build_process == RUN_ID):
+        elif (self.build_status == BuildStatus.building and self.container_build_process == RUN_ID):
             # build already started by this server
             return False
-        elif self.container_state == ContainerState.building:
+        elif self.build_status == BuildStatus.building:
             # build from a previous (crashed) server, clean up
             # await build.remove(db, container_id)
 
@@ -68,6 +66,6 @@ class Container():
             # build.remove(self.container_id)
             pass
 
-        self.container_state = ContainerState.building
+        self.build_status = BuildStatus.building
         self.container_build_process = RUN_ID
         return True

--- a/funcx_container_service/container.py
+++ b/funcx_container_service/container.py
@@ -1,6 +1,6 @@
 import uuid
 from . import callback_router
-from .models import BuildSpec, ContainerSpec, ContainerState
+from .models import BuildSpec, ContainerSpec, ContainerState, BuildCompletionSpec
 
 
 class Container():
@@ -46,11 +46,11 @@ class Container():
                                                             settings)
         return build_result
 
-    async def register_build_complete(self, result_dict, settings):
+    async def register_build_complete(self, completion_spec, settings):
 
-        post_dict = {**self.container_spec, **result_dict}
+        # post_dict = {**self.container_spec, **BuildCompletionSpec}
 
-        build_complete_result = await callback_router.register_build_complete(post_dict, settings)
+        build_complete_result = await callback_router.register_build_complete(completion_spec, settings)
 
         return build_complete_result
 

--- a/funcx_container_service/container.py
+++ b/funcx_container_service/container.py
@@ -46,6 +46,14 @@ class Container():
                                                             settings)
         return build_result
 
+    async def register_build_complete(self, result_dict, settings):
+
+        post_dict = {**self.container_spec, **result_dict}
+
+        build_complete_result = await callback_router.register_build_complete(post_dict, settings)
+
+        return build_complete_result
+
     def start_build(self, RUN_ID, settings):
         try:
             if self.container_state == ContainerState.ready:
@@ -54,8 +62,7 @@ class Container():
             elif self.container_state == ContainerState.failed:
                 # already failed, not going to change
                 return False
-            elif (self.container_state == ContainerState.building
-                    and self.container_build_process == RUN_ID):
+            elif (self.container_state == ContainerState.building and self.container_build_process == RUN_ID):
                 # build already started by this server
                 return False
             elif self.container_state == ContainerState.building:

--- a/funcx_container_service/models.py
+++ b/funcx_container_service/models.py
@@ -56,15 +56,15 @@ class BuildSpec(BaseModel):
     container_id: UUID
     build_id: UUID
     RUN_ID: UUID
+    build_status: ContainerState
 
 
 class BuildCompletionSpec(BuildSpec):
-    repo2docker_return_code: int
-    stdout: str
-    stderr: str
-    container_size: float
+    repo2docker_return_code: int = 0
+    stdout: Optional[str]
+    stderr: Optional[str]
+    container_size: float = 0
     docker_client_version: str
-    container_state: ContainerState
 
 
 class BuildResponse(BaseModel):

--- a/funcx_container_service/models.py
+++ b/funcx_container_service/models.py
@@ -58,6 +58,15 @@ class BuildSpec(BaseModel):
     RUN_ID: UUID
 
 
+class BuildCompletionSpec(BuildSpec):
+    repo2docker_return_code: int
+    stdout: str
+    stderr: str
+    container_size: float
+    docker_client_version: str
+    container_state: ContainerState
+
+
 class BuildResponse(BaseModel):
     container_id: UUID
     build_id: UUID

--- a/funcx_container_service/models.py
+++ b/funcx_container_service/models.py
@@ -45,10 +45,10 @@ class ContainerSpec(BaseModel):
         return hashlib.sha256(canonical.encode()).hexdigest()
 
 
-class ContainerState(str, Enum):
+class BuildStatus(str, Enum):
     pending = 'pending'
     building = 'building'
-    ready = 'ready'
+    complete = 'complete'
     failed = 'failed'
 
 
@@ -56,15 +56,21 @@ class BuildSpec(BaseModel):
     container_id: UUID
     build_id: UUID
     RUN_ID: UUID
-    build_status: ContainerState
+    build_status: BuildStatus
 
 
 class BuildCompletionSpec(BuildSpec):
     repo2docker_return_code: int = 0
-    stdout: Optional[str]
-    stderr: Optional[str]
+    repo2docker_stdout: Optional[str]
+    repo2docker_stderr: Optional[str]
     container_size: float = 0
     docker_client_version: str
+    registry_url: str = None
+    registry_repository: str = None
+    registry_user: str = None
+    docker_push_log: str = None
+    image_tag: str = None
+    image_pull_command: str = None
 
 
 class BuildResponse(BaseModel):

--- a/funcx_container_service/version.py
+++ b/funcx_container_service/version.py
@@ -1,0 +1,1 @@
+container_service_version = "1.0"

--- a/main.py
+++ b/main.py
@@ -1,0 +1,6 @@
+import uvicorn
+
+import funcx_container_service
+
+if __name__ == "__main__":
+    uvicorn.run(funcx_container_service.app, host="0.0.0.0", port=8000)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers = 
+	integration_test: marks tests for integration testing (vs unit testing)

--- a/tests/resources/test_build.py
+++ b/tests/resources/test_build.py
@@ -60,6 +60,7 @@ def apt_container_spec_fixture():
     return mock_spec
 
 
+@pytest.mark.integration_test
 @pytest.mark.asyncio
 async def test_repo2docker_build(container_id_fixture, temp_dir_fixture):
     print(f'building container id: {container_id_fixture}')
@@ -70,6 +71,7 @@ async def test_repo2docker_build(container_id_fixture, temp_dir_fixture):
     remove_image(container_id_fixture)
 
 
+@pytest.mark.integration_test
 @pytest.mark.asyncio
 async def test_empty_build_from_spec(container_id_fixture,
                                      blank_container_spec_fixture,
@@ -84,6 +86,7 @@ async def test_empty_build_from_spec(container_id_fixture,
     remove_image(container_id_fixture)
 
 
+@pytest.mark.integration_test
 @pytest.mark.asyncio
 async def test_pip_build_from_spec(container_id_fixture,
                                    pip_container_spec_fixture,
@@ -98,6 +101,7 @@ async def test_pip_build_from_spec(container_id_fixture,
     remove_image(container_id_fixture)
 
 
+@pytest.mark.integration_test
 @pytest.mark.asyncio
 async def test_apt_build_from_spec(container_id_fixture,
                                    apt_container_spec_fixture,

--- a/tests/resources/test_build.py
+++ b/tests/resources/test_build.py
@@ -6,7 +6,8 @@ import uuid
 from pathlib import Path
 import shutil
 
-from funcx_container_service.models import ContainerSpec
+from funcx_container_service.container import Container
+from funcx_container_service.models import ContainerSpec, BuildSpec
 from funcx_container_service.build import (repo2docker_build, build_spec_to_file, docker_name,
                                            DOCKER_BASE_URL, env_from_spec)
 
@@ -78,6 +79,26 @@ def combo_container_spec_fixture():
     return mock_spec
 
 
+@pytest.fixture
+def empty_container_fixture(blank_container_spec_fixture):
+    return Container(blank_container_spec_fixture, RUN_ID=uuid.uuid4())
+
+
+@pytest.fixture
+def pip_container_fixture(pip_container_spec_fixture):
+    return Container(pip_container_spec_fixture, RUN_ID=uuid.uuid4())
+
+
+@pytest.fixture
+def conda_container_fixture(conda_container_spec_fixture):
+    return Container(conda_container_spec_fixture, RUN_ID=uuid.uuid4())
+
+
+@pytest.fixture
+def apt_container_fixture(apt_container_spec_fixture):
+    return Container(apt_container_spec_fixture, RUN_ID=uuid.uuid4())
+
+
 def test_env_from_spec_pip(pip_container_spec_fixture):
     env = env_from_spec(pip_container_spec_fixture)
     assert env['dependencies'][1]['pip'] == pip_container_spec_fixture.pip
@@ -110,53 +131,53 @@ async def test_build_spec_to_file(container_id_fixture,
 
 @pytest.mark.integration_test
 @pytest.mark.asyncio
-async def test_empty_build_from_spec(container_id_fixture,
-                                     blank_container_spec_fixture,
+async def test_empty_build_from_spec(empty_container_fixture,
                                      temp_dir_fixture):
 
-    await build_spec_to_file(container_id_fixture,
-                             blank_container_spec_fixture,
+    await build_spec_to_file(empty_container_fixture.container_id,
+                             empty_container_fixture.container_spec,
                              temp_dir_fixture)
 
-    build_response = await repo2docker_build(container_id_fixture,
-                                             temp_dir_fixture)
+    build_response = await repo2docker_build(empty_container_fixture,
+                                             temp_dir_fixture,
+                                             '1.0')
 
-    assert build_response['repo2docker_return_code'] == 0
+    assert build_response.repo2docker_return_code == 0
 
-    remove_image(container_id_fixture)
+    remove_image(empty_container_fixture.container_id)
 
 
 @pytest.mark.integration_test
 @pytest.mark.asyncio
-async def test_pip_build_from_spec(container_id_fixture,
-                                   pip_container_spec_fixture,
+async def test_pip_build_from_spec(pip_container_fixture,
                                    temp_dir_fixture):
 
-    await build_spec_to_file(container_id_fixture,
-                             pip_container_spec_fixture,
+    await build_spec_to_file(pip_container_fixture.container_id,
+                             pip_container_fixture.container_spec,
                              temp_dir_fixture)
 
-    build_response = await repo2docker_build(container_id_fixture,
-                                             temp_dir_fixture)
+    build_response = await repo2docker_build(pip_container_fixture,
+                                             temp_dir_fixture,
+                                             '1.0')
 
-    assert build_response['repo2docker_return_code'] == 0
+    assert build_response.repo2docker_return_code == 0
 
-    remove_image(container_id_fixture)
+    remove_image(pip_container_fixture.container_id)
 
 
 @pytest.mark.integration_test
 @pytest.mark.asyncio
-async def test_apt_build_from_spec(container_id_fixture,
-                                   apt_container_spec_fixture,
+async def test_apt_build_from_spec(apt_container_fixture,
                                    temp_dir_fixture):
 
-    await build_spec_to_file(container_id_fixture,
-                             apt_container_spec_fixture,
+    await build_spec_to_file(apt_container_fixture.container_id,
+                             apt_container_fixture.container_spec,
                              temp_dir_fixture)
 
-    build_response = await repo2docker_build(container_id_fixture,
-                                             temp_dir_fixture)
+    build_response = await repo2docker_build(apt_container_fixture,
+                                             temp_dir_fixture,
+                                             '1.0')
 
-    assert build_response['repo2docker_return_code'] == 0
+    assert build_response.repo2docker_return_code == 0
 
-    remove_image(container_id_fixture)
+    remove_image(apt_container_fixture.container_id)

--- a/tests/resources/test_build.py
+++ b/tests/resources/test_build.py
@@ -6,7 +6,8 @@ from pathlib import Path
 import shutil
 
 from funcx_container_service.models import ContainerSpec
-from funcx_container_service.build import repo2docker_build, build_spec, docker_name, DOCKER_BASE_URL
+from funcx_container_service.build import (repo2docker_build, build_spec, docker_name,
+                                           DOCKER_BASE_URL, env_from_spec)
 
 
 def remove_image(container_id):
@@ -58,6 +59,15 @@ def apt_container_spec_fixture():
             apt=['rolldice']
         )
     return mock_spec
+
+
+def test_env_from_spec_pip(pip_container_spec_fixture):
+    env = env_from_spec(pip_container_spec_fixture)
+    assert env['dependencies'][1]['pip'] == pip_container_spec_fixture.pip
+
+
+def test_env_from_spec_conda():
+    return
 
 
 @pytest.mark.integration_test

--- a/tests/resources/test_build.py
+++ b/tests/resources/test_build.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import shutil
 
 from funcx_container_service.container import Container
-from funcx_container_service.models import ContainerSpec, BuildSpec
+from funcx_container_service.models import ContainerSpec
 from funcx_container_service.build import (repo2docker_build, build_spec_to_file, docker_name,
                                            DOCKER_BASE_URL, env_from_spec)
 

--- a/tests/resources/test_build.py
+++ b/tests/resources/test_build.py
@@ -34,52 +34,47 @@ def temp_dir_fixture():
 
 @pytest.fixture
 def blank_container_spec_fixture():
-    mock_spec = ContainerSpec(
-            container_type="Docker",
-            container_id=uuid.uuid4(),
-            apt=[]
-        )
+    mock_spec = ContainerSpec(container_type="Docker",
+                              container_id=uuid.uuid4(),
+                              apt=[]
+                              )
     return mock_spec
 
 
 @pytest.fixture
 def pip_container_spec_fixture():
-    mock_spec = ContainerSpec(
-            container_type="Docker",
-            container_id=uuid.uuid4(),
-            pip=['beautifulsoup4', 'flask==2.0.1', 'scikit-learn', 'pandas']
-        )
+    mock_spec = ContainerSpec(container_type="Docker",
+                              container_id=uuid.uuid4(),
+                              pip=['beautifulsoup4', 'flask==2.0.1', 'scikit-learn', 'pandas']
+                              )
     return mock_spec
 
 
 @pytest.fixture
 def apt_container_spec_fixture():
-    mock_spec = ContainerSpec(
-            container_type="Docker",
-            container_id=uuid.uuid4(),
-            apt=['rolldice']
-        )
+    mock_spec = ContainerSpec(container_type="Docker",
+                              container_id=uuid.uuid4(),
+                              apt=['rolldice']
+                              )
     return mock_spec
 
 
 @pytest.fixture
 def conda_container_spec_fixture():
-    mock_spec = ContainerSpec(
-            container_type="Docker",
-            container_id=uuid.uuid4(),
-            conda=['pandas']
-        )
+    mock_spec = ContainerSpec(container_type="Docker",
+                              container_id=uuid.uuid4(),
+                              conda=['pandas']
+                              )
     return mock_spec
 
 
 @pytest.fixture
 def combo_container_spec_fixture():
-    mock_spec = ContainerSpec(
-            container_type="Docker",
-            container_id=uuid.uuid4(),
-            conda=['pandas'],
-            pip=['beautifulsoup4', 'flask==2.0.1', 'scikit-learn']\
-        )
+    mock_spec = ContainerSpec(container_type="Docker",
+                              container_id=uuid.uuid4(),
+                              conda=['pandas'],
+                              pip=['beautifulsoup4', 'flask==2.0.1', 'scikit-learn']
+                              )
     return mock_spec
 
 
@@ -95,20 +90,20 @@ def test_env_from_spec_conda(conda_container_spec_fixture):
 
 def test_env_from_spec_combo(combo_container_spec_fixture):
     env = env_from_spec(combo_container_spec_fixture)
-    assert env['dependencies'] == ['pip', 
-                                     ', '.join(combo_container_spec_fixture.conda),
-                                     {'pip':combo_container_spec_fixture.pip}
-                                  ]
+    assert env['dependencies'] == ['pip',
+                                   ', '.join(combo_container_spec_fixture.conda),
+                                   {'pip': combo_container_spec_fixture.pip}
+                                   ]
 
 
 @pytest.mark.asyncio
 async def test_build_spec_to_file(container_id_fixture,
-                                     blank_container_spec_fixture,
-                                     temp_dir_fixture):
+                                  blank_container_spec_fixture,
+                                  temp_dir_fixture):
 
     await build_spec_to_file(container_id_fixture,
-                                      blank_container_spec_fixture,
-                                      temp_dir_fixture)
+                             blank_container_spec_fixture,
+                             temp_dir_fixture)
 
     assert os.path.exists(os.path.join(temp_dir_fixture, 'environment.yml'))
 
@@ -156,8 +151,8 @@ async def test_apt_build_from_spec(container_id_fixture,
                                    temp_dir_fixture):
 
     await build_spec_to_file(container_id_fixture,
-                                      apt_container_spec_fixture,
-                                      temp_dir_fixture)
+                             apt_container_spec_fixture,
+                             temp_dir_fixture)
 
     build_response = await repo2docker_build(container_id_fixture,
                                              temp_dir_fixture)

--- a/tests/resources/test_routes.py
+++ b/tests/resources/test_routes.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+from funcx_container_service.__init__ import app
+
+client = TestClient(app)
+
+
+def test_read_main():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"msg": "Hello World"}
+
+
+def test_read_verion():
+    response = client.get("/version")
+    # pdb.set_trace()
+    assert response.status_code == 200
+    assert response.json()["version"] is not None

--- a/tests/resources/test_routes.py
+++ b/tests/resources/test_routes.py
@@ -10,7 +10,7 @@ def test_read_main():
     assert response.json() == {"msg": "Hello World"}
 
 
-def test_read_verion():
+def test_read_version():
     response = client.get("/version")
     # pdb.set_trace()
     assert response.status_code == 200

--- a/web_svc_app.conf
+++ b/web_svc_app.conf
@@ -1,0 +1,11 @@
+#
+# FuncX WebService config file that can be used to test out the container
+# service. Run web service in docker as:
+#  docker run --rm -it -p 5000:5000 --mount "type=bind,source=$(pwd)/web_svc_app.conf,target=/opt/app.conf" --env APP_CONFIG_FILE=/opt/app.conf  funcx/web-service:container_service
+#
+SQLALCHEMY_DATABASE_URI = 'sqlite://'
+SQLALCHEMY_TRACK_MODIFICATIONS = False
+CONTAINER_SERVICE_ENABLED = True
+
+# URL of Container Service
+CONTAINER_SERVICE = "http://localhost:8000"


### PR DESCRIPTION
Incorporating pushing the built image to a docker registry stored in the .env file. Also refines the `PUT` routes used to update the build status of the container with the webservice, improves the callback documentation provided by the swagger interface, and improves the documentation in the readme.

Closes #12 