### PR TITLE
Container Service in Kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,10 @@ WORKDIR /opt/
 COPY ./requirements.txt .
 RUN pip install -r ./requirements.txt
 
+COPY main.py ./main.py
 COPY ./funcx_container_service/ ./funcx_container_service/
 
 USER http
-EXPOSE 5000
+EXPOSE 8000
 
-CMD uvicorn funcx_container_service:app --host '0.0.0.0' --port 5000
+CMD PYTHONPATH=./funcx_container_service python main.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,17 @@
-FROM python:3.7
-RUN apt-get update && \
-    apt-get install -y  gcc musl-dev && \
-    apt-get install -y  postgresql libffi-dev g++ make git
+FROM docker:dind-rootless
 
-RUN addgroup http && useradd http -g http
+ENV PYTHONUNBUFFERED=1
+USER root
+
+RUN apk add --update --no-cache python3 py3-ruamel.yaml.clib && ln -sf python3 /usr/bin/python
+RUN python3 -m ensurepip
+RUN pip3 install --no-cache --upgrade pip setuptools
+
+#RUN apt-get update && \
+#    apt-get install -y  gcc musl-dev && \
+#    apt-get install -y  postgresql libffi-dev g++ make git
+
+RUN addgroup http && adduser http -G http -D
 
 WORKDIR /opt/
 
@@ -13,7 +21,7 @@ RUN pip install -r ./requirements.txt
 COPY main.py ./main.py
 COPY ./funcx_container_service/ ./funcx_container_service/
 
-USER http
+USER rootless
 EXPOSE 8000
 
 CMD PYTHONPATH=./funcx_container_service python main.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,9 @@
-FROM docker:dind-rootless
+FROM python:3.7
+RUN apt-get update && \
+    apt-get install -y  gcc musl-dev && \
+    apt-get install -y  postgresql libffi-dev g++ make git
 
-ENV PYTHONUNBUFFERED=1
-USER root
-
-RUN apk add --update --no-cache python3 py3-ruamel.yaml.clib && ln -sf python3 /usr/bin/python
-RUN python3 -m ensurepip
-RUN pip3 install --no-cache --upgrade pip setuptools
-
-#RUN apt-get update && \
-#    apt-get install -y  gcc musl-dev && \
-#    apt-get install -y  postgresql libffi-dev g++ make git
-
-RUN addgroup http && adduser http -G http -D
+RUN addgroup http && useradd http -g http
 
 WORKDIR /opt/
 
@@ -21,7 +13,7 @@ RUN pip install -r ./requirements.txt
 COPY main.py ./main.py
 COPY ./funcx_container_service/ ./funcx_container_service/
 
-USER rootless
+USER http
 EXPOSE 8000
-
+ENV PYTHONUNBUFFERED=1
 CMD PYTHONPATH=./funcx_container_service python main.py

--- a/README.md
+++ b/README.md
@@ -24,6 +24,75 @@ The `REGISTRY` variables define the access information for the registry to which
 
 ## Running the service
 
+## Development Setups
+For the full container service experience you will want a local instance of the
+funcX webservice running, along with a compatible version of the funcX SDK.
+
+### Install the container_service branch of the sdk:
+In a clean virtual environment install the container service development 
+branch of the funcX SDK
+```shell
+pip install git+https://github.com/funcx-faas/funcX.git@container_service#subdirectory=funcx_sdk
+```
+
+### Run the Container Service
+There are two options for running the container service. If you just need it
+to be available, you can run a published docker image:
+```shell
+docker run --rm -it --env WEBSERVICE_URL=http://host.docker.internal:5000 -p 8000:8000 funcx/container-service:dev
+```
+This uses a macOS Docker feature for accessing the host's ports from within a 
+docker container.
+
+For development and debugging purposes, you can run the Container Service in
+pyCharm or other IDE. For this, setup a runtime configuration that runs the 
+script `main.py`. You will need to provide an environment variable to the 
+process that sets `WEBSERVICE_URL=http://localhost:5000`
+
+### Run the FuncX Web Service
+Likewise, there are the same two options for running the web service. If you
+just want to run the webservice you can use the container_service tagged 
+image. In this case, you need to provide the service with a config file. A 
+working config file is checked into _this_ repo, `web_svc_app.conf`. This 
+gets mounted into the container and run as:
+```shell
+docker run --rm -it -p 5000:5000 \
+       --mount "type=bind,source=$(pwd)/web_svc_app.conf,target=/opt/app.conf" \
+       --env APP_CONFIG_FILE=/opt/app.conf \
+       funcx/web-service:container_service
+```
+
+For development and debugging you can run the web service in pyCharm. That
+IDE directly supports flask apps. Just add an environment variable,
+```
+APP_CONFIG_FILE=../funcx-container-service/web_svc_app.conf
+```
+The web app will be running on port 5000 and expecting the container service 
+on port 8000.
+
+### Taking the Container Service out for a Spin
+With the container service enabled SDK, it's easy to submit a container 
+build request:
+```python
+from funcx import ContainerSpec, FuncXClient
+
+fxc = FuncXClient(funcx_service_address="http://localhost:5000/v2")
+container_uuid = fxc.build_container(
+    ContainerSpec(
+        name="MyContainer",
+        apt=[
+            "dvipng",
+            "ghostscript"
+        ],
+        pip=[
+            "cycler==0.10.0"
+        ],
+    )
+)
+
+print(f"Building {container_uuid}")
+print(f"status is {fxc.get_container_build_status(container_uuid)}")
+```
 You can run the service inside a docker container.
 
 ```

--- a/funcx_container_service/build.py
+++ b/funcx_container_service/build.py
@@ -81,7 +81,7 @@ async def simple_background_build(container: Container,
                     push_image(image_name, completion_spec, settings)
 
                     # update container state upon successful build
-                    container.build_status = BuildStatus.complete
+                    container.build_status = BuildStatus.ready
 
         finally:
 
@@ -118,6 +118,7 @@ async def repo2docker_build(container, temp_dir, docker_client_version):
 
     process = await asyncio.create_subprocess_shell(REPO2DOCKER_CMD.format(docker_name(container.container_id),
                                                                            temp_dir),
+                                                    env={"DOCKER_HOST": DOCKER_BASE_URL},
                                                     stdout=asyncio.subprocess.PIPE,
                                                     stderr=asyncio.subprocess.PIPE)
 

--- a/funcx_container_service/callback_router.py
+++ b/funcx_container_service/callback_router.py
@@ -79,7 +79,8 @@ async def register_building(container: Container, settings: Settings):
         response = await client.put(urljoin(
             settings.WEBSERVICE_URL,
             f"v2/containers/{build_spec.container_id}/status"),
-            json=build_spec.json())
+            headers={'Content-Type': 'application/json'},
+            content=build_spec.json())
 
         if response.status_code != 200:
             log.error(f"register build sent back {response}")
@@ -105,7 +106,8 @@ async def register_build_starting(container: Container, settings: Settings):
         response = await client.put(urljoin(
             settings.WEBSERVICE_URL,
             f"v2/containers/{build_spec.container_id}/status"),
-            json=build_spec.json())
+            headers={'Content-Type': 'application/json'},
+            content=build_spec.json())
 
         if response.status_code != 200:
             log.error(f"register build start sent back {response}")
@@ -123,7 +125,8 @@ async def register_build_complete(completion_spec: BuildCompletionSpec, settings
         response = await client.put(urljoin(
             settings.WEBSERVICE_URL,
             f"v2/containers/{completion_spec.container_id}/status"),
-            json=completion_spec.json())
+            headers={'Content-Type': 'application/json'},
+            content=completion_spec.json())
 
         if response.status_code != 200:
             log.error(f"register build complete sent back {response}")

--- a/funcx_container_service/container.py
+++ b/funcx_container_service/container.py
@@ -16,7 +16,7 @@ class Container():
         self.container_id = container_spec.container_id
         self.build_id = str(uuid.uuid4())
         self.RUN_ID = RUN_ID
-        self.build_status = BuildStatus.pending
+        self.build_status = BuildStatus.queued
         self.container_build_process = None
         self.build_spec = None
 
@@ -49,7 +49,7 @@ class Container():
 
     def start_build(self, RUN_ID, settings):
 
-        if self.build_status == BuildStatus.complete:
+        if self.build_status == BuildStatus.ready:
             # nothing to do
             return False
         elif self.build_status == BuildStatus.failed:

--- a/funcx_container_service/models.py
+++ b/funcx_container_service/models.py
@@ -46,9 +46,9 @@ class ContainerSpec(BaseModel):
 
 
 class BuildStatus(str, Enum):
-    pending = 'pending'
+    queued = 'queued'
     building = 'building'
-    complete = 'complete'
+    ready = 'ready'
     failed = 'failed'
 
 

--- a/main.py
+++ b/main.py
@@ -1,0 +1,6 @@
+import uvicorn
+
+import funcx_container_service
+
+if __name__ == "__main__":
+    uvicorn.run(funcx_container_service.app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jupyter-repo2docker
-fastapi[all]
+fastapi[uvicorn]
 python-multipart
 uvicorn
 SQLAlchemy

--- a/tests/resources/test_build.py
+++ b/tests/resources/test_build.py
@@ -117,6 +117,7 @@ def test_env_from_spec_combo(combo_container_spec_fixture):
                                    ]
 
 
+@pytest.mark.integration_test
 @pytest.mark.asyncio
 async def test_build_spec_to_file(container_id_fixture,
                                   blank_container_spec_fixture,
@@ -145,7 +146,6 @@ async def test_empty_build_from_spec(empty_container_fixture,
     assert build_response.repo2docker_return_code == 0
 
     remove_image(empty_container_fixture.container_id)
-
 
 @pytest.mark.integration_test
 @pytest.mark.asyncio

--- a/tests/resources/test_build.py
+++ b/tests/resources/test_build.py
@@ -147,6 +147,7 @@ async def test_empty_build_from_spec(empty_container_fixture,
 
     remove_image(empty_container_fixture.container_id)
 
+
 @pytest.mark.integration_test
 @pytest.mark.asyncio
 async def test_pip_build_from_spec(pip_container_fixture,

--- a/web_svc_app.conf
+++ b/web_svc_app.conf
@@ -1,0 +1,11 @@
+#
+# FuncX WebService config file that can be used to test out the container
+# service. Run web service in docker as:
+#  docker run --rm -it -p 5000:5000 --mount "type=bind,source=$(pwd)/web_svc_app.conf,target=/opt/app.conf" --env APP_CONFIG_FILE=/opt/app.conf  funcx/web-service:container_service
+#
+SQLALCHEMY_DATABASE_URI = 'sqlite://'
+SQLALCHEMY_TRACK_MODIFICATIONS = False
+CONTAINER_SERVICE_ENABLED = True
+
+# URL of Container Service
+CONTAINER_SERVICE = "http://localhost:8000"

--- a/web_svc_app.conf
+++ b/web_svc_app.conf
@@ -9,3 +9,5 @@ CONTAINER_SERVICE_ENABLED = True
 
 # URL of Container Service
 CONTAINER_SERVICE = "http://localhost:8000"
+GLOBUS_CLIENT = "123-456-789"
+GLOBUS_KEY = "Shh/hush="


### PR DESCRIPTION
This PR includes changes that allow the Container service to run inside Kubernetes and also corrects some mismatches between the container service and the web service.

Finally, it includes some changes that make the service more debugable and easier to run in an IDE.

## More Debuggable
We needed a `main.py` that can be invoked to run the container service. This required changes to the Dockerfile. I also included a stub app.conf for the web service to work with a local container service. The README has extensive instructions.

The Dockerfile was also changed to make the python output appear in realtime in the logs

## Integration with WebService
The WebService is expecting messages with mime type of `application/json` - the `.to_json` functions in pedantic return strings. I changed the httpx calls to use those strings as content and then explicitly set the mime type

The WebService has a fixed set of build states. I updated the Container Service to use these