### PR TITLE
Update container type to all lower case

### DIFF
--- a/funcx_container_service/models.py
+++ b/funcx_container_service/models.py
@@ -10,8 +10,8 @@ class ContainerRuntime(str, Enum):
     """
     Specification of the runtime to be used to execute the container.
     """
-    docker = 'Docker'
-    singularity = 'Singularity'
+    docker = 'docker'
+    singularity = 'singularity'
 
 
 class BuildType(str, Enum):

--- a/tests/resources/test_container.py
+++ b/tests/resources/test_container.py
@@ -25,7 +25,7 @@ def settings_fixture():
 
 @pytest.fixture
 def container_spec_fixture():
-    mock_spec = ContainerSpec(container_type="Docker",
+    mock_spec = ContainerSpec(container_type="docker",
                               container_id=uuid.uuid4(),
                               payload_url='http://www.example.com',
                               conda=['pandas'],


### PR DESCRIPTION
For consistency we would like the container type values to be all lower case.

This needs to be deployed alongside the matching [funcx PR 279](https://github.com/globusonline/funcx-services/pull/279) 