### PR TITLE
Don't delete the temp directory from within the context manager

### DIFF
--- a/tests/resources/test_build.py
+++ b/tests/resources/test_build.py
@@ -2,6 +2,7 @@ import pytest
 import subprocess
 import tempfile
 import uuid
+import os
 
 import docker
 
@@ -60,11 +61,13 @@ def test_repo2docker_build_success(container_spec_fixture, settings_fixture, fp,
 
 def test_repo2docker_build_fail(container_spec_fixture, settings_fixture, fp, mocker):
     with tempfile.TemporaryDirectory() as temp_dir:
+        deleteme = os.path.join(temp_dir, "deleteme")
+        os.mkdir(deleteme)
         run_id = str(uuid.uuid4())
         c = Container(container_spec_fixture,
                       run_id,
                       settings_fixture,
-                      temp_dir,
+                      deleteme,
                       DOCKER_BASE_URL)
         c.build_type = BuildType.container
 
@@ -80,11 +83,14 @@ def test_repo2docker_build_fail(container_spec_fixture, settings_fixture, fp, mo
 
 def test_background_build(container_spec_fixture, settings_fixture, mocker, fp):
     with tempfile.TemporaryDirectory() as temp_dir:
+        deleteme = os.path.join(temp_dir, "deleteme")
+        os.mkdir(deleteme)
+
         run_id = str(uuid.uuid4())
         c = Container(container_spec_fixture,
                       run_id,
                       settings_fixture,
-                      temp_dir,
+                      deleteme,
                       DOCKER_BASE_URL)
         c.build_type = BuildType.container
 
@@ -146,11 +152,14 @@ def test_repo2docker_docker_exception(container_spec_fixture, settings_fixture, 
 def test_background_build_docker_exception(container_spec_fixture, settings_fixture, mocker, fp):
 
     with tempfile.TemporaryDirectory() as temp_dir:
+        deleteme = os.path.join(temp_dir, "deleteme")
+        os.mkdir(deleteme)
+
         run_id = str(uuid.uuid4())
         container = Container(container_spec_fixture,
                               run_id,
                               settings_fixture,
-                              temp_dir,
+                              deleteme,
                               DOCKER_BASE_URL)
         container.build_type = BuildType.container
 
@@ -166,11 +175,14 @@ def test_background_build_docker_exception(container_spec_fixture, settings_fixt
 def test_background_build_timeout_exception(container_spec_fixture, settings_fixture, mocker, fp):
 
     with tempfile.TemporaryDirectory() as temp_dir:
+        deleteme = os.path.join(temp_dir, "deleteme")
+        os.mkdir(deleteme)
+
         run_id = str(uuid.uuid4())
         container = Container(container_spec_fixture,
                               run_id,
                               settings_fixture,
-                              temp_dir,
+                              deleteme,
                               DOCKER_BASE_URL)
         container.build_type = BuildType.container
 

--- a/tests/resources/test_container.py
+++ b/tests/resources/test_container.py
@@ -61,26 +61,32 @@ def test_container_creation(container_spec_fixture, settings_fixture):
 
 def test_uncompress_zip(container_spec_fixture, settings_fixture):
     with tempfile.TemporaryDirectory() as temp_dir:
-        shutil.copyfile("tests/resources/data.txt.zip", f'{temp_dir}/data.txt.zip')
+        deleteme = os.path.join(temp_dir, "deleteme")
+        os.mkdir(deleteme)
+
+        shutil.copyfile("tests/resources/data.txt.zip", f'{deleteme}/data.txt.zip')
         run_id = str(uuid.uuid4())
         c = Container(container_spec_fixture,
                       run_id,
                       settings_fixture,
-                      temp_dir,
+                      deleteme,
                       DOCKER_BASE_URL)
 
-        c.uncompress_payload(f'{temp_dir}/data.txt.zip')
-        assert os.path.exists(f'{temp_dir}/test.txt')
+        c.uncompress_payload(f'{deleteme}/data.txt.zip')
+        assert os.path.exists(f'{deleteme}/test.txt')
 
 
 def test_uncompress_non_zip(container_spec_fixture, settings_fixture, mocker):
     with tempfile.TemporaryDirectory() as temp_dir:
+        deleteme = os.path.join(temp_dir, "deleteme")
+        os.mkdir(deleteme)
+
         shutil.copyfile("tests/resources/test.txt", f'{temp_dir}/test.txt')
         run_id = str(uuid.uuid4())
         c = Container(container_spec_fixture,
                       run_id,
                       settings_fixture,
-                      temp_dir,
+                      deleteme,
                       DOCKER_BASE_URL)
         with pytest.raises(Exception):
             mocker.patch("funcx_container_service.container.Container.log_error")
@@ -89,12 +95,15 @@ def test_uncompress_non_zip(container_spec_fixture, settings_fixture, mocker):
 
 def test_update_build_type_github(container_spec_fixture, settings_fixture):
     with tempfile.TemporaryDirectory() as temp_dir:
+        deleteme = os.path.join(temp_dir, "deleteme")
+        os.mkdir(deleteme)
+
         shutil.copyfile("tests/resources/data.txt.zip", f'{temp_dir}/data.txt.zip')
         run_id = str(uuid.uuid4())
         c = Container(container_spec_fixture,
                       run_id,
                       settings_fixture,
-                      temp_dir,
+                      deleteme,
                       DOCKER_BASE_URL)
 
         c.update_build_type()


### PR DESCRIPTION
Fixes errors in the container service tests. The problem was that the `background_build` method is deleting `temp_directory` upon completion. We were passing in the directory produced by the context manager `tempfile.TemporaryDirectory()` which gets upset if the directory is deleted inside the context.

I made a subdirectory which can be safely deleted.